### PR TITLE
Add underlining buffering to SIO transports

### DIFF
--- a/transport/interface.go
+++ b/transport/interface.go
@@ -18,7 +18,7 @@ type Transporter interface {
 }
 
 type Sender interface {
-	Send(socketID SocketID, data Data, opts ...Option) error
+	Send(SocketID, Data, ...Option) error
 }
 
 type SendReceiver interface {


### PR DESCRIPTION
Now we can buffer EIO packets before we send them. 

This allows for collecting packets before sending a 
connect packet.