### PR TITLE
Fix EIO protocol Handshake and  HTTP Polling

### DIFF
--- a/engineio/protocol/packet.v3.go
+++ b/engineio/protocol/packet.v3.go
@@ -67,7 +67,7 @@ func (enc *PacketEncoderV3) Encode(packet PacketV3) (err error) {
 	switch packet.T {
 	case OpenPacket:
 		switch data := packet.D.(type) {
-		case HandshakeV3:
+		case *HandshakeV3:
 			if data.Upgrades == nil {
 				data.Upgrades = []string{}
 			}


### PR DESCRIPTION
**Fix** the `HandshakeV3` protocol by changing it to a pointer so that changes
can be reflected when updated and so that the type matches when checking
the packet data during the type conversion to the wire representation 
(bytes).
**Fix** the polling transport so that it sends more than one packet in
a payload when there are several packets in the queue.