### PR TITLE
EIO functional options version compatibility

### DIFF
--- a/engineio/server.v3.go
+++ b/engineio/server.v3.go
@@ -60,6 +60,8 @@ func (v3 *serverV3) new(opts ...Option) *serverV3 {
 	return v3
 }
 
+func (v3 *serverV3) prev() Server { return v3.serverV2 }
+
 func (v3 *serverV3) serveHTTP(w http.ResponseWriter, r *http.Request) error {
 	if origin := r.Header.Get("Origin"); origin != "" && v3.cors.enable {
 		if v3.cors.credentials {

--- a/engineio/server.v4.go
+++ b/engineio/server.v4.go
@@ -38,3 +38,5 @@ func (v4 *serverV4) new(opts ...Option) *serverV4 {
 	v4.With(v4, opts...)
 	return v4
 }
+
+func (v4 *serverV4) prev() Server { return v4.serverV3 }

--- a/engineio/server.v5.go
+++ b/engineio/server.v5.go
@@ -53,3 +53,5 @@ func (v5 *serverV5) new(opts ...Option) *serverV5 {
 	v5.With(v5, opts...)
 	return v5
 }
+
+func (v5 *serverV5) prev() Server { return v5.serverV4 }


### PR DESCRIPTION
**Update** the EIO server so that it can look through previous server
versions when applying functional options to a server version. Now
later versions of the server can use a functional option for a previous
version.

There was a bug in how the functional option was applied previously.
While previous versions would get the option applied it would be overwritten
by later versions as they were initialized. Because the later server
versions did not match the version of the server the functional option
could apply to, it would not reflect the change that the functional
option intended. This is now mitigated by looking though previous
versions of the server that the functional option is applied to.

**:label: NOTE:** Because we are looking through every functional option on every
previous version initialization, there is an __*O(n^n)*__ effect that could
slow down code that has many options.