### PR TITLE
Allow any value for a parameter

### DIFF
--- a/callback/callback.go
+++ b/callback/callback.go
@@ -83,7 +83,8 @@ func (fn Wrap) Callback(data ...interface{}) (err error) {
 			vStr = strings.TrimRight(vStr, ".0")
 			val.Unserialize(vStr)
 		default:
-			return ErrBadParamType
+			in[i] = reflect.ValueOf(v)
+			continue
 		}
 		if vv, ok := val.(interface{ Interface() interface{} }); ok {
 			in[i] = reflect.ValueOf(vv.Interface())


### PR DESCRIPTION
Before an unknown parameter would create an `ErrBadParamType`. That
prevented passing objects and maps. Now it will just pass the value of
the parameter through, without an error.