### PR TITLE
Add ReadBinary interface and small fixes

### DIFF
--- a/protocol/packet.pac.ns.go
+++ b/protocol/packet.pac.ns.go
@@ -4,7 +4,7 @@ package protocol
 type packetNS string
 
 func (x packetNS) Len() int {
-	if x == "/" {
+	if x == "/" || x == "" {
 		return 0
 	}
 	return len(x) + 1 // +1 for the comma

--- a/protocol/packet.v2.msgpack.go
+++ b/protocol/packet.v2.msgpack.go
@@ -48,15 +48,20 @@ func packetDataArrayUnmarshalV2(data []byte, v interface{}) error {
 		for i, field := range (*fields)[1:] {
 			switch datum := field.(type) {
 			case map[string]interface{}:
-				if isBase64, ok := datum["base64"].(bool); !ok || !isBase64 {
-					continue
-				} else if _, ok := datum["data"].(string); !ok {
+				isBase64, _ := datum["base64"].(bool)
+
+				if _, ok := datum["data"].(string); !ok {
 					continue
 				}
 
 				var raw, buf []byte
-				if raw, err = base64.StdEncoding.DecodeString(datum["data"].(string)); err != nil {
-					return ErrBadFieldBase64Decode.F(err)
+				if isBase64 {
+					if raw, err = base64.StdEncoding.DecodeString(datum["data"].(string)); err != nil {
+						return ErrBadFieldBase64Decode.F(err)
+					}
+				} else {
+					rawStr, _ := datum["data"].(string)
+					raw = []byte(rawStr)
 				}
 				if err = msgpack.Unmarshal(raw, &buf); err != nil {
 					return ErrBadFieldMsgPackDecode.F(err)

--- a/protocol/packet.v2_test.go
+++ b/protocol/packet.v2_test.go
@@ -24,7 +24,7 @@ func mergeWriteV2(dst, src map[string]func() ([]byte, PacketV2, error)) {
 }
 
 func TestPacketV2Read(t *testing.T) {
-	var opts = []testoption{runTest("ACK with Object and Binary.ReadFrom")}
+	var opts = []testoption{}
 
 	testchecks := map[string]func(checks ...testoption) testReadV2{
 		".ReadFrom": func(checks ...testoption) testReadV2 {
@@ -175,7 +175,7 @@ func TestPacketV2Read(t *testing.T) {
 }
 
 func TestWritePacketV2(t *testing.T) {
-	var opts []testoption
+	var opts = []testoption{}
 
 	testcheck := func(checks ...testoption) testWriteV2 {
 		return func(data []byte, want PacketV2, xerr error) func(*testing.T) {

--- a/protocol/packet.v4.go
+++ b/protocol/packet.v4.go
@@ -130,6 +130,14 @@ func (pac *PacketV4) Write(p []byte) (n int, err error) {
 	return pac.scratch.write.n, pac.scratch.write.err
 }
 
+func (pac *PacketV4) ReadBinary() (bin func(r io.Reader) error) {
+	if len(pac.incoming) == 0 {
+		return nil
+	}
+	bin, pac.incoming = pac.incoming[0], pac.incoming[1:]
+	return bin
+}
+
 func binaryTypeCheckV4(_type *packetType) writeStateFn {
 	return func(p []byte) stateFn {
 		return func(scr *scratch) stateFn {

--- a/protocol/packet.v5.go
+++ b/protocol/packet.v5.go
@@ -151,6 +151,14 @@ func (pac *PacketV5) Write(p []byte) (n int, err error) {
 	return pac.scratch.write.n, pac.scratch.write.err
 }
 
+func (pac *PacketV5) ReadBinary() (bin func(r io.Reader) error) {
+	if len(pac.incoming) == 0 {
+		return nil
+	}
+	bin, pac.incoming = pac.incoming[0], pac.incoming[1:]
+	return bin
+}
+
 func binaryTypeCheckV5(_type *packetType) writeStateFn {
 	return binaryTypeCheckV4(_type)
 }


### PR DESCRIPTION
**Add** the ReadBinary method to satisfy a ReadBinary interface to allow SIO packet version 4 and 5 to accept binary data from clients.
**Update** the namespace struct so that the Len() count is accurate for empty namespaces.
**Fix** the msgpack logic so that it can accept non-base64 encoded data values.
**Add** a Reader that can propagate errors from io.Copy to the reader, so that any errors can be properly managed even if it comes from the io.Copy embedded within a go-routine.