### PR TITLE
Fix -race conditions

### DIFF
--- a/engineio/protocol/handshake.v2.go
+++ b/engineio/protocol/handshake.v2.go
@@ -31,7 +31,9 @@ func (h *HandshakeV2) Len() int {
 	// Now the data
 	if h.PingTimeout > 0 {
 		inSeconds := h.PingTimeout / Duration(time.Millisecond)
-		n += int(math.Floor(math.Log10(float64(inSeconds))))
+		if inSeconds > 0 {
+			n += int(math.Floor(math.Log10(float64(inSeconds))))
+		}
 	}
 	n += len(h.SID)
 	for i, v := range h.Upgrades {

--- a/engineio/protocol/utility.go
+++ b/engineio/protocol/utility.go
@@ -1,61 +1,34 @@
 package protocol
 
 import (
-	"bufio"
-	"bytes"
-	"errors"
 	"io"
 	"unicode/utf8"
 )
 
-// CopyRuneN copies n runes (or until an error) from src to dst. It returns the number
-// of runes copied and the earliest error encountered while copying. On return, written
-// == n, if and only if err == nil.
-func CopyRuneN(dst io.Writer, src io.Reader, n int64) (written int64, err error) {
-	// this is the first implentation... so it may not be really efficient...
-	// but as of now it works and passes tests...
-	if n == 0 {
-		return n, nil
-	}
-
-	var (
-		overflow  [3]byte
-		prevx, x  int
-		prev, cnt int64
-	)
-
-ReadMore:
-	adv := (n - cnt) + int64(x)
-	buf := bufio.NewReader(io.LimitReader(io.MultiReader(bytes.NewReader(overflow[:x]), src), adv))
-	prevx, x = x, 0 // clear for the next go round...
-	for ; cnt < n; cnt++ {
-		r, size, err := buf.ReadRune()
-		if r == utf8.RuneError && size == 1 {
-			buf.UnreadRune()
-			x, err = buf.Read(overflow[:])
-			if err != nil {
-				return cnt, err
-			}
-			if x == prevx {
-				return cnt, ErrInvalidRune
-			}
-			goto ReadMore
-		}
-		prevx = 0 // clear because it's outside of the RuneError
-		if err != nil && errors.Is(err, io.EOF) {
-			if cnt > 0 && prev == cnt { // if no change then we're done
-				return cnt, err
-			}
-			prev = cnt
-			goto ReadMore
-		}
-		if err != nil {
-			return cnt, err
-		}
-		_, err = dst.Write([]byte(string(r)))
-		if err != nil {
-			return cnt, err
-		}
-	}
-	return cnt, err
+type limitRuneReader struct {
+	r io.Reader
+	n int64
 }
+
+func (lr *limitRuneReader) Read(p []byte) (n int, err error) {
+	if lr.n <= 0 {
+		return 0, io.EOF
+	}
+
+	var s int
+	n = int(lr.n)
+	if int64(len(p)) < lr.n {
+		n = len(p)
+	}
+	_, err = lr.r.Read(p[s:n]) // 10
+	for !utf8.Valid(p[0:n]) && n <= len(p) {
+		s = n
+		n++
+		_, err = lr.r.Read(p[s:n])
+	}
+
+	lr.n -= int64(utf8.RuneCount(p[0:n]))
+	return
+}
+
+func LimitRuneReader(r io.Reader, n int64) io.Reader { return &limitRuneReader{r: r, n: n} }

--- a/engineio/protocol/utility.json.go
+++ b/engineio/protocol/utility.json.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"io"
 	"strconv"
 	"time"
 )
@@ -20,14 +19,4 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 func (d Duration) MarshalJSON() (b []byte, err error) {
 	c := strconv.Itoa(int(time.Duration(d) / time.Millisecond))
 	return []byte(c), nil
-}
-
-// This is because of https://golang.org/src/encoding/json/stream.go?s=4272:4319#L173
-type stripLastNewlineWriter struct{ w io.Writer }
-
-func (snw *stripLastNewlineWriter) Write(p []byte) (n int, err error) {
-	if n = len(p) - 1; p[n] != '\n' { // assumes this is not in the middle of a write...
-		n++
-	}
-	return snw.w.Write(p[:n])
 }

--- a/server.v1.go
+++ b/server.v1.go
@@ -102,11 +102,23 @@ func (v1 *ServerV1) with(svr Server, opts ...Option) {
 	}
 }
 
-func (v1 *ServerV1) In(room Room) inToEmit { v1.setIsServer(true); return v1.inSocketV1.In(room) }
+func (v1 *ServerV1) In(room Room) inToEmit {
+	rtn := v1.clone()
+	rtn.setIsServer(true)
+	return rtn.In(room)
+}
 
-func (v1 *ServerV1) Of(ns Namespace) inSocketV1 { v1.setIsServer(true); return v1.inSocketV1.Of(ns) }
+func (v1 *ServerV1) Of(ns Namespace) inSocketV1 {
+	rtn := v1.clone()
+	v1.setIsServer(true)
+	return rtn.Of(ns)
+}
 
-func (v1 *ServerV1) To(room Room) inToEmit { v1.setIsServer(true); return v1.inSocketV1.To(room) }
+func (v1 *ServerV1) To(room Room) inToEmit {
+	rtn := v1.clone()
+	rtn.setIsServer(true)
+	return rtn.To(room)
+}
 
 // ServeHTTP is the interface for applying a http request/response cycle. This handles
 // errors that can be provided by the underlining serveHTTP method that uses errors.

--- a/server.v2.go
+++ b/server.v2.go
@@ -48,10 +48,22 @@ func (v2 *ServerV2) new(opts ...Option) Server {
 
 func (v2 *ServerV2) With(opts ...Option) { v1 := v2.prev; v1.with(v2, opts...) }
 
-func (v2 *ServerV2) In(room Room) inToEmit { v2.setIsServer(true); return v2.inSocketV2.In(room) }
+func (v2 *ServerV2) In(room Room) inToEmit {
+	rtn := v2.clone()
+	rtn.setIsServer(true)
+	return rtn.In(room)
+}
 
-func (v2 *ServerV2) Of(ns Namespace) inSocketV2 { v2.setIsServer(true); return v2.inSocketV2.Of(ns) }
+func (v2 *ServerV2) Of(ns Namespace) inSocketV2 {
+	rtn := v2.clone()
+	rtn.setIsServer(true)
+	return rtn.Of(ns)
+}
 
-func (v2 *ServerV2) To(room Room) inToEmit { v2.setIsServer(true); return v2.inSocketV2.To(room) }
+func (v2 *ServerV2) To(room Room) inToEmit {
+	rtn := v2.clone()
+	rtn.setIsServer(true)
+	return rtn.To(room)
+}
 
 func (v2 *ServerV2) ServeHTTP(w http.ResponseWriter, r *http.Request) { v2.prev.ServeHTTP(w, r) }

--- a/server.v3.go
+++ b/server.v3.go
@@ -52,10 +52,22 @@ func (v3 *ServerV3) new(opts ...Option) Server {
 
 func (v3 *ServerV3) With(opts ...Option) { v1 := v3.prev.prev; v1.with(v3, opts...) }
 
-func (v3 *ServerV3) In(room Room) inToEmit { v3.setIsServer(true); return v3.inSocketV3.In(room) }
+func (v3 *ServerV3) In(room Room) inToEmit {
+	rtn := v3.clone()
+	rtn.setIsServer(true)
+	return rtn.In(room)
+}
 
-func (v3 *ServerV3) Of(ns Namespace) inSocketV3 { v3.setIsServer(true); return v3.inSocketV3.Of(ns) }
+func (v3 *ServerV3) Of(ns Namespace) inSocketV3 {
+	rtn := v3.clone()
+	rtn.setIsServer(true)
+	return rtn.Of(ns)
+}
 
-func (v3 *ServerV3) To(room Room) inToEmit { v3.setIsServer(true); return v3.inSocketV3.To(room) }
+func (v3 *ServerV3) To(room Room) inToEmit {
+	rtn := v3.clone()
+	rtn.setIsServer(true)
+	return rtn.To(room)
+}
 
 func (v3 *ServerV3) ServeHTTP(w http.ResponseWriter, r *http.Request) { v3.prev.ServeHTTP(w, r) }

--- a/server.v4.go
+++ b/server.v4.go
@@ -48,23 +48,27 @@ func (v4 *ServerV4) new(opts ...Option) Server {
 func (v4 *ServerV4) With(opts ...Option) { v1 := v4.prev.prev.prev; v1.with(v4, opts...) }
 
 func (v4 *ServerV4) Except(room ...Room) innTooExceptEmit {
-	v4.setIsServer(true)
-	return v4.inSocketV4.Except(room...)
+	rtn := v4.clone()
+	rtn.setIsServer(true)
+	return rtn.Except(room...)
 }
 
 func (v4 *ServerV4) In(room ...Room) innTooExceptEmit {
-	v4.setIsServer(true)
-	return v4.inSocketV4.In(room...)
+	rtn := v4.clone()
+	rtn.setIsServer(true)
+	return rtn.In(room...)
 }
 
 func (v4 *ServerV4) Of(namespace Namespace) inSocketV4 {
-	v4.setIsServer(true)
-	return v4.inSocketV4.Of(namespace)
+	rtn := v4.clone()
+	rtn.setIsServer(true)
+	return rtn.Of(namespace)
 }
 
 func (v4 *ServerV4) To(room ...Room) innTooExceptEmit {
-	v4.setIsServer(true)
-	return v4.inSocketV4.To(room...)
+	rtn := v4.clone()
+	rtn.setIsServer(true)
+	return rtn.To(room...)
 }
 
 func (v4 *ServerV4) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Removes race conditions from the code found by using -race in testing.
Removes the CopyRuneN function that required using a go routine to work
if favor of using a LimitedReader which doesn't require a go routine and
potentially cause race conditions.