### PR TITLE
Fix the len value for string Data objects

### DIFF
--- a/protocol/packet.pac.data.go
+++ b/protocol/packet.pac.data.go
@@ -37,7 +37,7 @@ func (x packetDataString) Len() int {
 	if x.x == nil {
 		return 0
 	}
-	return len(*x.x)
+	return len(*x.x) + 2 // the +2 is for "" quote marks
 }
 
 func (x *packetDataString) Read(p []byte) (n int, err error) {


### PR DESCRIPTION
When using a string data object, `Len() int` would under report the
length by 2 characters, because the quote marks were not being taken
into account.