### PR TITLE
Refactor Protocol/Payload - decoding/encoding

### DIFF
--- a/engineio/protocol/packet.go
+++ b/engineio/protocol/packet.go
@@ -1,8 +1,9 @@
 package protocol
 
 import (
-	"encoding/json"
 	"io"
+
+	"github.com/njones/socketio/internal/readwriter"
 )
 
 const (
@@ -27,17 +28,11 @@ const (
 )
 
 type (
-	_packetJSONDecoder func(io.Reader) *json.Decoder
-	_packetJSONEncoder func(io.Writer) *json.Encoder
+	_packetJSONDecoder   = readwriter.JSONDecoder
+	_packetBase64Decoder = readwriter.Base64Decoder
+	_packetJSONEncoder   = readwriter.JSONEncoderStripNewline
+	_packetBase64encoder = readwriter.Base64Encoder
 )
-
-func (fn _packetJSONDecoder) From(r io.Reader) func(interface{}) error { return fn(r).Decode }
-func (fn _packetJSONEncoder) To(w io.Writer) func(interface{}) error {
-	return fn(&stripLastNewlineWriter{w}).Encode
-}
-
-func newJSONDecoder() _packetJSONDecoder { return json.NewDecoder }
-func newJSONEncoder() _packetJSONEncoder { return json.NewEncoder }
 
 type Packet struct {
 	T PacketType  `json:"type"`
@@ -57,7 +52,7 @@ func (pac Packet) Len() int {
 	case nil:
 		return n
 	case string:
-		return n + len(d)
+		return n + len([]rune(d))
 	case useLen:
 		return n + d.Len()
 	}

--- a/engineio/protocol/packet.v2.codec.go
+++ b/engineio/protocol/packet.v2.codec.go
@@ -17,7 +17,7 @@ func (pac _packetEncoderV2) To(w io.Writer) PacketWriter   { return _packetWrite
 func (pac _packetReaderV2) ReadPacket(packet PacketRef) (err error) {
 	var v = PacketV2{Packet: *packet.PacketRef()}
 	err = pac(&v)
-	*packet.PacketRef() = v.Packet // add even if err becuase when using Decode this is what happens
+	*packet.PacketRef() = v.Packet // add even if err because when using Decode this is what happens
 	return err
 }
 func (pac _packetWriterV2) WritePacket(packet PacketVal) error {

--- a/engineio/protocol/packet.v4.go
+++ b/engineio/protocol/packet.v4.go
@@ -36,7 +36,7 @@ func (dec *PacketDecoderV4) Decode(packet *PacketV4) error {
 	switch packet.T {
 	case BinaryPacket:
 		var data = new(bytes.Buffer)
-		dec.read.Base64(base64.StdEncoding).Copy(data).OnErrF(ErrPacketDecode, "v4", dec.read.Err())
+		dec.read.SetDecoder(_packetBase64Decoder(base64.NewDecoder)).Decode(data).OnErrF(ErrPacketDecode, "v4", dec.read.Err())
 		packet.IsBinary = true
 		packet.D = (io.Reader)(data)
 		return dec.read.Err()
@@ -63,9 +63,9 @@ func (enc *PacketEncoderV4) Encode(packet PacketV4) (err error) {
 		enc.write.Bytes(packet.T.Bytes()).OnErrF(ErrPacketEncode, "v4", enc.write.Err())
 		switch data := packet.D.(type) {
 		case []byte:
-			enc.write.Base64(base64.StdEncoding).Bytes(data).OnErrF(ErrPacketEncode, "v4", enc.write.Err())
+			enc.write.UseEncoder(_packetBase64encoder(base64.NewEncoder)).Encode(data).OnErrF(ErrPacketEncode, "v4", enc.write.Err())
 		case io.Reader:
-			enc.write.Base64(base64.StdEncoding).Copy(data).OnErrF(ErrPacketEncode, "v4", enc.write.Err())
+			enc.write.UseEncoder(_packetBase64encoder(base64.NewEncoder)).Encode(data).OnErrF(ErrPacketEncode, "v4", enc.write.Err())
 		default:
 			return fmt.Errorf("bad packet dinary encode type: %T", data)
 		}

--- a/engineio/protocol/payload.go
+++ b/engineio/protocol/payload.go
@@ -26,3 +26,10 @@ type reader struct {
 	*rw.Reader
 	err error
 }
+
+type writer struct {
+	*rw.Writer
+	err error
+}
+
+func (w writer) PropagateWriter() *rw.Writer { return w.Writer }

--- a/engineio/protocol/payload.v2.go
+++ b/engineio/protocol/payload.v2.go
@@ -37,10 +37,10 @@ func (dec *PayloadDecoderV2) Decode(payload *PayloadV2) error {
 	return dec.read.ConvertErr(io.EOF, nil).Err()
 }
 
-type PayloadEncoderV2 struct{ write *rw.Writer }
+type PayloadEncoderV2 struct{ write *writer }
 
 var NewPayloadEncoderV2 _payloadEncoderV2 = func(w io.Writer) *PayloadEncoderV2 {
-	return &PayloadEncoderV2{write: rw.NewWriter(w)}
+	return &PayloadEncoderV2{write: &writer{Writer: rw.NewWriter(w)}}
 }
 
 func (enc *PayloadEncoderV2) Encode(payload PayloadV2) error {

--- a/engineio/protocol/payload.v2.rw.go
+++ b/engineio/protocol/payload.v2.rw.go
@@ -27,10 +27,5 @@ func (rdr *reader) packetLen() (n int64) {
 }
 
 func (rdr *reader) payload(n int64) io.Reader {
-	pr, pw := io.Pipe()
-	go func() {
-		CopyRuneN(pw, rdr.Bufio(), n)
-		pw.Close()
-	}()
-	return pr
+	return LimitRuneReader(rdr.Bufio(), n)
 }

--- a/engineio/protocol/payload.v3.codec.go
+++ b/engineio/protocol/payload.v3.codec.go
@@ -28,7 +28,15 @@ type _payloadWriterV3 func(pay PayloadV3) (err error)
 func (pay _payloadEncoderV3) SetXHR2(isXHR2 bool) _payloadEncoderV3 {
 	return func(w io.Writer) *PayloadEncoderV3 {
 		enc := pay(w)
-		enc.IsXHR2 = isXHR2
+		enc.hasXHR2Support = isXHR2
+		return enc
+	}
+}
+
+func (pay _payloadEncoderV3) SetBinary(isBinary bool) _payloadEncoderV3 {
+	return func(w io.Writer) *PayloadEncoderV3 {
+		enc := pay(w)
+		enc.hasBinarySupport = isBinary
 		return enc
 	}
 }
@@ -36,7 +44,15 @@ func (pay _payloadEncoderV3) SetXHR2(isXHR2 bool) _payloadEncoderV3 {
 func (pay _payloadDecoderV3) SetXHR2(isXHR2 bool) _payloadDecoderV3 {
 	return func(r io.Reader) *PayloadDecoderV3 {
 		dec := pay(r)
-		dec.IsXHR2 = isXHR2
+		dec.hasXHR2Support = isXHR2
+		return dec
+	}
+}
+
+func (pay _payloadDecoderV3) SetBinary(isBinary bool) _payloadDecoderV3 {
+	return func(r io.Reader) *PayloadDecoderV3 {
+		dec := pay(r)
+		dec.hasBinarySupport = isBinary
 		return dec
 	}
 }

--- a/engineio/protocol/payload.v4.go
+++ b/engineio/protocol/payload.v4.go
@@ -43,7 +43,7 @@ type PayloadEncoderV4 struct{ *PayloadEncoderV3 }
 var NewPayloadEncoderV4 _payloadEncoderV4 = func(w io.Writer) *PayloadEncoderV4 {
 	return &PayloadEncoderV4{
 		PayloadEncoderV3: &PayloadEncoderV3{
-			PayloadEncoderV2: &PayloadEncoderV2{write: rw.NewWriter(w)},
+			PayloadEncoderV2: &PayloadEncoderV2{write: &writer{Writer: rw.NewWriter(w)}},
 		},
 	}
 }

--- a/engineio/transport/utility.go
+++ b/engineio/transport/utility.go
@@ -1,15 +1,5 @@
 package transport
 
-import "net/http"
-
 type socketClose struct{ error }
 
 func (sc socketClose) SocketCloseChannel() error { return sc.error }
-
-func jsonpFrom(r *http.Request) *string {
-	j := r.URL.Query().Get("j")
-	if j != "" {
-		return &j
-	}
-	return nil
-}

--- a/internal/readwriter/read.go
+++ b/internal/readwriter/read.go
@@ -26,6 +26,7 @@ type rdrCondBool interface {
 
 type Reader struct {
 	r   *bufio.Reader
+	dec decodeReader
 	err error
 }
 

--- a/internal/readwriter/write.go
+++ b/internal/readwriter/write.go
@@ -14,6 +14,7 @@ type wtrErr interface {
 
 type Writer struct {
 	w   *bufio.Writer
+	enc encWriter
 	err error
 }
 
@@ -29,4 +30,9 @@ func (wtr *Writer) OnErr(errs.String)                  {}
 func (wtr *Writer) OnErrF(errs.String, ...interface{}) {}
 func (wtr *Writer) Write(p []byte) (n int, err error)  { return wtr.w.Write(p) }
 
-func NewWriter(w io.Writer) *Writer { return &Writer{w: bufio.NewWriter(w)} }
+func NewWriter(w io.Writer) *Writer {
+	if ww, ok := w.(interface{ PropagateWriter() *Writer }); ok {
+		return ww.PropagateWriter()
+	}
+	return &Writer{w: bufio.NewWriter(w)}
+}


### PR DESCRIPTION
Updates the EngineIO protocol and payload encoding/decoding methods to
be more clear. Updates the Binary support to not be based on if the
packet is Binary but rather if the protocol supports binary.
Updates the JSON and Base64 encoding to satisfy a common interface and
be added to the rw.Writer and rw.Reader structs so they can be used in
a fluid manner.