### PR TITLE
Refactor and add tests

### DIFF
--- a/callback/callback_test.go
+++ b/callback/callback_test.go
@@ -1,0 +1,132 @@
+package callback
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/njones/socketio/serialize"
+)
+
+func eventCallback(in ...interface{}) func(interface{ Callback(...interface{}) error }) error {
+	return func(fn interface{ Callback(...interface{}) error }) error {
+		return fn.Callback(in...)
+	}
+}
+
+func ExampleErrorWrap() {
+	err := eventCallback()(
+
+		// This wraps a function that takes no arguments
+		// and returns an error
+		ErrorWrap(func() error {
+			return fmt.Errorf("sad")
+		}),
+	)
+
+	fmt.Println("err:", err)
+
+	// Output: err: sad
+}
+
+func ExampleFuncString() {
+
+	eventCallback("World")(
+
+		// This wraps a function that takes a string as an argument and
+		// and doesn't return
+		FuncString(func(str string) {
+			fmt.Println("Hello", str)
+		}),
+	)
+
+	// Output: Hello World
+}
+
+func ExampleWrap() {
+
+	// This can make any function callable without creating the interface
+
+	err := eventCallback("Pan", "Wendy")(
+
+		// Wrap takes in an object that represents a function
+		// with parameters and an error output
+		Wrap{
+			Parameters: []serialize.Serializable{serialize.StrParam, serialize.StrParam},
+			Func: func() interface{} {
+				return func(last, first string) error {
+					fmt.Println("Peter", last)
+					fmt.Println(first, "Darling")
+					return fmt.Errorf("Boys")
+				}
+			},
+		},
+	)
+
+	fmt.Println("The Lost", err)
+
+	eventCallback(1, "too", math.Pi, strings.NewReader("FORE"))(
+
+		// Wrap takes in an object that represents a function
+		// with parameters and an error output. Note how the
+		// output of the function is a function that accepts
+		// the parameters as arguments.
+		Wrap{
+			Parameters: []serialize.Serializable{
+				serialize.IntParam, serialize.StrParam, serialize.F64Param, serialize.BinParam,
+			},
+			Func: func() interface{} {
+				return func(one int, two string, three float64, four io.Reader) error {
+					fmt.Println("The number:", one)
+					fmt.Println("This takes:", two)
+					fmt.Println("To make my:", three)
+					fmt.Print("Stream out: ")
+					_, err := io.Copy(os.Stdout, four)
+					return err
+				}
+			},
+		},
+	)
+
+	// Output:
+	// Peter Pan
+	// Wendy Darling
+	// The Lost Boys
+	// The number: 1
+	// This takes: too
+	// To make my: 3.141592653589793
+	// Stream out: FORE
+}
+
+type CustomWrap func(string, string) error
+
+func (cc CustomWrap) Callback(data ...interface{}) error {
+	a, aOK := data[0].(string)
+	b, bOK := data[1].(string)
+
+	if !aOK || !bOK {
+		return fmt.Errorf("bad parameters")
+	}
+
+	return cc(a, b)
+}
+
+func ExampleCustomWrap() {
+
+	// This can make any function callable without creating the interface
+
+	err := eventCallback("Pan", "Wendy")(CustomWrap(func(last, first string) error {
+		fmt.Println("Peter", last)
+		fmt.Println(first, "Darling")
+		return nil
+	}))
+
+	fmt.Println("Error", err)
+
+	// Output:
+	// Peter Pan
+	// Wendy Darling
+	// Error <nil>
+}

--- a/engineio/protocol/packet.v2_test.go
+++ b/engineio/protocol/packet.v2_test.go
@@ -4,6 +4,7 @@ package protocol
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -12,14 +13,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type testoption func(*testing.T)
+var testingName = strings.NewReplacer(" ", "_")
 
-func runTest(testnames ...string) testoption {
+func runTest(testNames ...string) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
-		names := strings.SplitN(t.Name(), "/", 2)
-		for _, testname := range testnames {
-			if names[len(names)-1] == strings.ReplaceAll(testname, " ", "_") {
+
+		have := strings.SplitN(t.Name(), "/", 2)[1]
+		suffix := strings.Split(have, ".")[1]
+
+		for _, testName := range testNames {
+			if testName == "" || testName == "*" {
+				return
+			}
+
+			want := testingName.Replace(testName)
+			if !strings.Contains(want, ".") {
+				want += "." + suffix
+			}
+			if have == want {
 				return
 			}
 		}
@@ -28,195 +40,185 @@ func runTest(testnames ...string) testoption {
 }
 
 func TestReadPacketV2(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(string, PacketV2, error) func(*testing.T){
-		".Decode": func(opts ...testoption) func(string, PacketV2, error) func(*testing.T) {
-			return func(data string, want PacketV2, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data string, want PacketV2, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data string, want PacketV2, xerr error)
+	)
 
-					var have PacketV2
-					var err = NewPacketDecoderV2(strings.NewReader(data)).Decode(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+	runWithOptions := map[string]testParamsInFn{
+		"Decode": func(data string, want PacketV2, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have PacketV2
+				var err = NewPacketDecoderV2(strings.NewReader(data)).Decode(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
-		".ReadPacket": func(opts ...testoption) func(string, PacketV2, error) func(*testing.T) {
-			return func(data string, want PacketV2, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var decoder _packetDecoderV2 = NewPacketDecoderV2
-
-					var have PacketV2
-					var err = decoder.From(strings.NewReader(data)).ReadPacket(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+		"ReadPacket": func(data string, want PacketV2, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var decoder _packetDecoderV2 = NewPacketDecoderV2
+
+				var have PacketV2
+				var err = decoder.From(strings.NewReader(data)).ReadPacket(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
 	}
 
-	spec := map[string]func() (string, PacketV2, error){
-		"Open": func() (string, PacketV2, error) {
+	spec := map[string]testParamsOutFn{
+		"Open": func(*testing.T) (string, PacketV2, error) {
 			data := `0{"sid":"abc123","upgrades":[],"pingTimeout":300}`
 			want := PacketV2{Packet{T: OpenPacket, D: &HandshakeV2{SID: "abc123", Upgrades: []string{}, PingTimeout: Duration(300 * time.Millisecond)}}}
 			return data, want, nil
 		},
-		"Close": func() (string, PacketV2, error) {
+		"Close": func(*testing.T) (string, PacketV2, error) {
 			data := `1`
 			want := PacketV2{Packet{T: ClosePacket, D: nil}}
 			return data, want, nil
 		},
-		"Ping": func() (string, PacketV2, error) {
+		"Ping": func(*testing.T) (string, PacketV2, error) {
 			data := `2`
 			want := PacketV2{Packet{T: PingPacket, D: nil}}
 			return data, want, nil
 		},
-		"Pong with Text": func() (string, PacketV2, error) {
+		"Pong with Text": func(*testing.T) (string, PacketV2, error) {
 			data := `3probe`
 			want := PacketV2{Packet{T: PongPacket, D: "probe"}}
 			return data, want, nil
 		},
-		"Message": func() (string, PacketV2, error) {
+		"Message": func(*testing.T) (string, PacketV2, error) {
 			data := `4HelloWorld`
 			want := PacketV2{Packet{T: MessagePacket, D: "HelloWorld"}}
 			return data, want, nil
 		},
-		"Upgrade": func() (string, PacketV2, error) {
+		"Upgrade": func(*testing.T) (string, PacketV2, error) {
 			data := `5`
 			want := PacketV2{Packet{T: UpgradePacket, D: nil}}
 			return data, want, nil
 		},
-		"NOOP": func() (string, PacketV2, error) {
+		"NOOP": func(*testing.T) (string, PacketV2, error) {
 			data := `6`
 			want := PacketV2{Packet{T: NoopPacket, D: nil}}
 			return data, want, nil
 		},
-	}
 
-	errs := map[string]func() (string, PacketV2, error){
-		"Open Err JSON": func() (string, PacketV2, error) {
+		// extra
+		"Open Err JSON": func(*testing.T) (string, PacketV2, error) {
 			data := `0{"sid":"abc1`
 			err := ErrHandshakeDecode.F("v2", io.ErrUnexpectedEOF)
 			return data, PacketV2{Packet{D: new(HandshakeV2)}}, err
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
-		}
-	}
-
-	for name, testing := range errs {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }
 
 func TestWritePacketV2(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(PacketV2, string, error) func(*testing.T){
-		".Encode": func(opts ...testoption) func(PacketV2, string, error) func(*testing.T) {
-			return func(data PacketV2, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data PacketV2, want string, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data PacketV2, want string, xerr error)
+	)
 
-					var have = new(bytes.Buffer)
-					var err = NewPacketEncoderV2(have).Encode(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+	runWithOptions := map[string]testParamsInFn{
+		"Encode": func(data PacketV2, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var err = NewPacketEncoderV2(have).Encode(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
-		".WritePacket": func(opts ...testoption) func(PacketV2, string, error) func(*testing.T) {
-			return func(data PacketV2, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var encoder _packetEncoderV2 = NewPacketEncoderV2
-
-					var have = new(bytes.Buffer)
-					var err = encoder.To(have).WritePacket(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+		"WritePacket": func(data PacketV2, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var encoder _packetEncoderV2 = NewPacketEncoderV2
+
+				var have = new(bytes.Buffer)
+				var err = encoder.To(have).WritePacket(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
 	}
 
-	spec := map[string]func() (PacketV2, string, error){
-		"Open": func() (PacketV2, string, error) {
+	spec := map[string]testParamsOutFn{
+		"Open": func(*testing.T) (PacketV2, string, error) {
 			want := `0{"sid":"abc123","upgrades":[],"pingTimeout":300}`
 			data := PacketV2{Packet{T: OpenPacket, D: &HandshakeV2{SID: "abc123", PingTimeout: Duration(300 * time.Millisecond)}}}
 			return data, want, nil
 		},
-		"Close": func() (PacketV2, string, error) {
+		"Close": func(*testing.T) (PacketV2, string, error) {
 			want := `1`
 			data := PacketV2{Packet{T: ClosePacket, D: nil}}
 			return data, want, nil
 		},
-		"Ping": func() (PacketV2, string, error) {
+		"Ping": func(*testing.T) (PacketV2, string, error) {
 			want := `2`
 			data := PacketV2{Packet{T: PingPacket, D: nil}}
 			return data, want, nil
 		},
-		"Pong with Text": func() (PacketV2, string, error) {
+		"Pong with Text": func(*testing.T) (PacketV2, string, error) {
 			want := `3probe`
 			data := PacketV2{Packet{T: PongPacket, D: "probe"}}
 			return data, want, nil
 		},
-		"Message": func() (PacketV2, string, error) {
+		"Message": func(*testing.T) (PacketV2, string, error) {
 			want := `4HelloWorld`
 			data := PacketV2{Packet{T: MessagePacket, D: "HelloWorld"}}
 			return data, want, nil
 		},
-		"Upgrade": func() (PacketV2, string, error) {
+		"Upgrade": func(*testing.T) (PacketV2, string, error) {
 			want := `5`
 			data := PacketV2{Packet{T: UpgradePacket, D: nil}}
 			return data, want, nil
 		},
-		"NOOP": func() (PacketV2, string, error) {
+		"NOOP": func(*testing.T) (PacketV2, string, error) {
 			want := `6`
 			data := PacketV2{Packet{T: NoopPacket, D: nil}}
 			return data, want, nil
 		},
-	}
 
-	errs := map[string]func() (PacketV2, string, error){
-		"Err PacketType": func() (PacketV2, string, error) {
+		// extra
+		"Err PacketType": func(*testing.T) (PacketV2, string, error) {
 			data := PacketV2{Packet{T: 200, D: nil}}
 			err := ErrInvalidPacketType
 			return data, "", err
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
-		}
-	}
-
-	for name, testing := range errs {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }

--- a/engineio/protocol/packet.v3_test.go
+++ b/engineio/protocol/packet.v3_test.go
@@ -4,6 +4,7 @@ package protocol
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -12,45 +13,47 @@ import (
 )
 
 func TestReadPacketV3(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(string, bool, PacketV3, error) func(*testing.T){
-		".Decode": func(opts ...testoption) func(string, bool, PacketV3, error) func(*testing.T) {
-			return func(data string, isBin bool, want PacketV3, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data string, isBin bool, want PacketV3, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data string, isBin bool, want PacketV3, xerr error)
+	)
 
-					var have = PacketV3{IsBinary: isBin}
-					var err = NewPacketDecoderV3(strings.NewReader(data)).Decode(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+	runWithOptions := map[string]testParamsInFn{
+		"Decode": func(data string, isBin bool, want PacketV3, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = PacketV3{IsBinary: isBin}
+				var err = NewPacketDecoderV3(strings.NewReader(data)).Decode(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
-		".ReadPacket": func(opts ...testoption) func(string, bool, PacketV3, error) func(*testing.T) {
-			return func(data string, isBin bool, want PacketV3, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var decoder _packetDecoderV3 = NewPacketDecoderV3
-
-					var have = PacketV3{IsBinary: isBin}
-					var err = decoder.From(strings.NewReader(data)).ReadPacket(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+		"ReadPacket": func(data string, isBin bool, want PacketV3, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var decoder _packetDecoderV3 = NewPacketDecoderV3
+
+				var have = PacketV3{IsBinary: isBin}
+				var err = decoder.From(strings.NewReader(data)).ReadPacket(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
 	}
 
-	spec := map[string]func() (string, bool, PacketV3, error){
-		"Open": func() (string, bool, PacketV3, error) {
+	spec := map[string]testParamsOutFn{
+		"Open": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := `0{"sid":"abc123","upgrades":[],"pingTimeout":300,"pingInterval":5000}`
 			want := PacketV3{
@@ -65,52 +68,51 @@ func TestReadPacketV3(t *testing.T) {
 			}
 			return data, isBin, want, nil
 		},
-		"Close": func() (string, bool, PacketV3, error) {
+		"Close": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := `1`
 			want := PacketV3{Packet{T: ClosePacket, D: nil}, false}
 			return data, isBin, want, nil
 		},
-		"Ping": func() (string, bool, PacketV3, error) {
+		"Ping": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := `2`
 			want := PacketV3{Packet{T: PingPacket, D: nil}, false}
 			return data, isBin, want, nil
 		},
-		"Pong with Text": func() (string, bool, PacketV3, error) {
+		"Pong with Text": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := `3probe`
 			want := PacketV3{Packet{T: PongPacket, D: "probe"}, false}
 			return data, isBin, want, nil
 		},
-		"Message": func() (string, bool, PacketV3, error) {
+		"Message": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := `4HelloWorld`
 			want := PacketV3{Packet{T: MessagePacket, D: "HelloWorld"}, false}
 			return data, isBin, want, nil
 		},
-		"Message with Binary": func() (string, bool, PacketV3, error) {
+		"Message with Binary": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := "4\x00\x01\x02\x03\x04\x05"
 			want := PacketV3{Packet{T: MessagePacket, D: "\x00\x01\x02\x03\x04\x05"}, false}
 			return data, isBin, want, nil
 		},
-		"Upgrade": func() (string, bool, PacketV3, error) {
+		"Upgrade": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := `5`
 			want := PacketV3{Packet{T: UpgradePacket, D: nil}, false}
 			return data, isBin, want, nil
 		},
-		"NOOP": func() (string, bool, PacketV3, error) {
+		"NOOP": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin bool
 			data := `6`
 			want := PacketV3{Packet{T: NoopPacket, D: nil}, false}
 			return data, isBin, want, nil
 		},
-	}
 
-	extra := map[string]func() (string, bool, PacketV3, error){
-		"Message with Binary": func() (string, bool, PacketV3, error) {
+		// extra
+		"Message with Binary #2": func(*testing.T) (string, bool, PacketV3, error) {
 			var isBin = true
 			data := "4\x00\x01\x02\x03\x04\x05"
 			want := PacketV3{Packet{T: MessagePacket, D: bytes.NewReader([]byte("\x00\x01\x02\x03\x04\x05"))}, true}
@@ -118,66 +120,60 @@ func TestReadPacketV3(t *testing.T) {
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
-		}
-	}
-
-	for name, testing := range extra {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }
 
 func TestWritePacketV3(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(PacketV3, string, error) func(*testing.T){
-		".Encode": func(opts ...testoption) func(PacketV3, string, error) func(*testing.T) {
-			return func(data PacketV3, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data PacketV3, want string, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data PacketV3, want string, xerr error)
+	)
 
-					var have = new(bytes.Buffer)
-					var err = NewPacketEncoderV3(have).Encode(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+	runWithOptions := map[string]testParamsInFn{
+		"Encode": func(data PacketV3, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var err = NewPacketEncoderV3(have).Encode(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
-		".WritePacket": func(opts ...testoption) func(PacketV3, string, error) func(*testing.T) {
-			return func(data PacketV3, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var encoder _packetEncoderV3 = NewPacketEncoderV3
-
-					var have = new(bytes.Buffer)
-					var err = encoder.To(have).WritePacket(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+		"WritePacket": func(data PacketV3, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var encoder _packetEncoderV3 = NewPacketEncoderV3
+
+				var have = new(bytes.Buffer)
+				var err = encoder.To(have).WritePacket(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
 	}
 
-	type params func() (PacketV3, string, error)
-
-	spec := map[string]params{
-		"Open": func() (PacketV3, string, error) {
+	spec := map[string]testParamsOutFn{
+		"Open": func(*testing.T) (PacketV3, string, error) {
 			want := `0{"sid":"abc123","upgrades":[],"pingTimeout":300,"pingInterval":5000}`
 			data := PacketV3{
 				Packet: Packet{
 					T: OpenPacket,
-					D: HandshakeV3{
+					D: &HandshakeV3{
 						HandshakeV2:  HandshakeV2{SID: "abc123", Upgrades: []string{}, PingTimeout: Duration(300 * time.Millisecond)},
 						PingInterval: Duration(5000 * time.Millisecond),
 					},
@@ -186,56 +182,53 @@ func TestWritePacketV3(t *testing.T) {
 			}
 			return data, want, nil
 		},
-		"Close": func() (PacketV3, string, error) {
+		"Close": func(*testing.T) (PacketV3, string, error) {
 			want := `1`
 			data := PacketV3{Packet{T: ClosePacket, D: nil}, false}
 			return data, want, nil
 		},
-		"Ping": func() (PacketV3, string, error) {
+		"Ping": func(*testing.T) (PacketV3, string, error) {
 			data := PacketV3{Packet{T: PingPacket, D: nil}, false}
 			want := `2`
 			return data, want, nil
 		},
-		"Pong with Text": func() (PacketV3, string, error) {
+		"Pong with Text": func(*testing.T) (PacketV3, string, error) {
 			want := `3probe`
 			data := PacketV3{Packet{T: PongPacket, D: "probe"}, false}
 			return data, want, nil
 		},
-		"Message": func() (PacketV3, string, error) {
+		"Message": func(*testing.T) (PacketV3, string, error) {
 			want := `4HelloWorld`
 			data := PacketV3{Packet{T: MessagePacket, D: "HelloWorld"}, false}
 			return data, want, nil
 		},
-		"Message with Binary": func() (PacketV3, string, error) {
+		"Message with Binary": func(*testing.T) (PacketV3, string, error) {
 			want := "4\x00\x01\x02\x03\x04\x05"
 			data := PacketV3{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5})}, false}
 			return data, want, nil
 		},
-		"Upgrade": func() (PacketV3, string, error) {
+		"Upgrade": func(*testing.T) (PacketV3, string, error) {
 			want := `5`
 			data := PacketV3{Packet{T: UpgradePacket, D: nil}, false}
 			return data, want, nil
 		},
-		"NOOP": func() (PacketV3, string, error) {
+		"NOOP": func(*testing.T) (PacketV3, string, error) {
 			want := `6`
 			data := PacketV3{Packet{T: NoopPacket, D: nil}, false}
 			return data, want, nil
 		},
-	}
 
-	extra := map[string]params{
-		"Message with Binary": func() (PacketV3, string, error) {
+		// extra
+		"Message with Binary #2": func(*testing.T) (PacketV3, string, error) {
 			want := "4\x00\x01\x02\x03\x04\x05"
 			data := PacketV3{Packet{T: MessagePacket, D: "\x00\x01\x02\x03\x04\x05"}, false}
 			return data, want, nil
 		},
 	}
 
-	for _, cases := range []map[string]params{spec, extra} {
-		for name, testing := range cases {
-			for suffix, runWithOption := range runWithOptions {
-				t.Run(name+suffix, runWithOption(opts...)(testing()))
-			}
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }

--- a/engineio/protocol/packet.v4_test.go
+++ b/engineio/protocol/packet.v4_test.go
@@ -4,6 +4,7 @@ package protocol
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -12,45 +13,47 @@ import (
 )
 
 func TestReadPacketV4(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(string, PacketV4, error) func(*testing.T){
-		".Decode": func(opts ...testoption) func(string, PacketV4, error) func(*testing.T) {
-			return func(data string, want PacketV4, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data string, want PacketV4, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data string, want PacketV4, xerr error)
+	)
 
-					var have PacketV4
-					var err = NewPacketDecoderV4(strings.NewReader(data)).Decode(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+	runWithOptions := map[string]testParamsInFn{
+		"Decode": func(data string, want PacketV4, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have PacketV4
+				var err = NewPacketDecoderV4(strings.NewReader(data)).Decode(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
-		".ReadPacket": func(opts ...testoption) func(string, PacketV4, error) func(*testing.T) {
-			return func(data string, want PacketV4, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var decoder _packetDecoderV4 = NewPacketDecoderV4
-
-					var have PacketV4
-					var err = decoder.From(strings.NewReader(data)).ReadPacket(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+		"ReadPacket": func(data string, want PacketV4, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var decoder _packetDecoderV4 = NewPacketDecoderV4
+
+				var have PacketV4
+				var err = decoder.From(strings.NewReader(data)).ReadPacket(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
 	}
 
-	spec := map[string]func() (string, PacketV4, error){
-		"Open": func() (string, PacketV4, error) {
+	spec := map[string]testParamsOutFn{
+		"Open": func(*testing.T) (string, PacketV4, error) {
 			data := `0{"sid":"abc123","upgrades":[],"pingTimeout":300,"pingInterval":5000}`
 			want := PacketV4{
 				PacketV3: PacketV3{
@@ -69,96 +72,99 @@ func TestReadPacketV4(t *testing.T) {
 			}
 			return data, want, nil
 		},
-		"Close": func() (string, PacketV4, error) {
+		"Close": func(*testing.T) (string, PacketV4, error) {
 			data := `1`
 			want := PacketV4{PacketV3: PacketV3{Packet{T: ClosePacket, D: nil}, false}}
 			return data, want, nil
 		},
-		"Ping": func() (string, PacketV4, error) {
+		"Ping": func(*testing.T) (string, PacketV4, error) {
 			data := `2`
 			want := PacketV4{PacketV3: PacketV3{Packet{T: PingPacket, D: nil}, false}}
 			return data, want, nil
 		},
-		"Pong with Text": func() (string, PacketV4, error) {
+		"Pong with Text": func(*testing.T) (string, PacketV4, error) {
 			data := `3probe`
 			want := PacketV4{PacketV3: PacketV3{Packet{T: PongPacket, D: "probe"}, false}}
 			return data, want, nil
 		},
-		"Message": func() (string, PacketV4, error) {
+		"Message": func(*testing.T) (string, PacketV4, error) {
 			data := `4HelloWorld`
 			want := PacketV4{PacketV3: PacketV3{Packet{T: MessagePacket, D: "HelloWorld"}, false}}
 			return data, want, nil
 		},
-		"Message with Binary": func() (string, PacketV4, error) {
+		"Message with Binary": func(*testing.T) (string, PacketV4, error) {
 			data := "4\x00\x01\x02\x03\x04\x05"
 			want := PacketV4{PacketV3: PacketV3{Packet{T: MessagePacket, D: "\x00\x01\x02\x03\x04\x05"}, false}}
 			return data, want, nil
 		},
-		"Upgrade": func() (string, PacketV4, error) {
+		"Upgrade": func(*testing.T) (string, PacketV4, error) {
 			data := `5`
 			want := PacketV4{PacketV3: PacketV3{Packet{T: UpgradePacket, D: nil}, false}}
 			return data, want, nil
 		},
-		"NOOP": func() (string, PacketV4, error) {
+		"NOOP": func(*testing.T) (string, PacketV4, error) {
 			data := `6`
 			want := PacketV4{PacketV3: PacketV3{Packet{T: NoopPacket, D: nil}, false}}
 			return data, want, nil
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }
 
 func TestWritePacketV4(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(PacketV4, string, error) func(*testing.T){
-		".Encode": func(opts ...testoption) func(PacketV4, string, error) func(*testing.T) {
-			return func(data PacketV4, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data PacketV4, want string, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data PacketV4, want string, xerr error)
+	)
 
-					var have = new(bytes.Buffer)
-					var err = NewPacketEncoderV4(have).Encode(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+	runWithOptions := map[string]testParamsInFn{
+		"Encode": func(data PacketV4, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var err = NewPacketEncoderV4(have).Encode(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
+
 		},
-		".WritePacket": func(opts ...testoption) func(PacketV4, string, error) func(*testing.T) {
-			return func(data PacketV4, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var encoder _packetEncoderV4 = NewPacketEncoderV4
-
-					var have = new(bytes.Buffer)
-					var err = encoder.To(have).WritePacket(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+		"WritePacket": func(data PacketV4, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var encoder _packetEncoderV4 = NewPacketEncoderV4
+
+				var have = new(bytes.Buffer)
+				var err = encoder.To(have).WritePacket(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
 	}
 
-	spec := map[string]func() (PacketV4, string, error){
-		"Open": func() (PacketV4, string, error) {
+	spec := map[string]testParamsOutFn{
+		"Open": func(*testing.T) (PacketV4, string, error) {
 			want := `0{"sid":"abc123","upgrades":[],"pingTimeout":300,"pingInterval":5000}`
 			data := PacketV4{
 				PacketV3: PacketV3{
 					Packet: Packet{
 						T: OpenPacket,
-						D: HandshakeV3{
+						D: &HandshakeV3{
 							HandshakeV2: HandshakeV2{
 								SID:         "abc123",
 								Upgrades:    []string{},
@@ -171,46 +177,46 @@ func TestWritePacketV4(t *testing.T) {
 			}
 			return data, want, nil
 		},
-		"Close": func() (PacketV4, string, error) {
+		"Close": func(*testing.T) (PacketV4, string, error) {
 			want := `1`
 			data := PacketV4{PacketV3: PacketV3{Packet{T: ClosePacket, D: nil}, false}}
 			return data, want, nil
 		},
-		"Ping": func() (PacketV4, string, error) {
+		"Ping": func(*testing.T) (PacketV4, string, error) {
 			want := `2`
 			data := PacketV4{PacketV3: PacketV3{Packet{T: PingPacket, D: nil}, false}}
 			return data, want, nil
 		},
-		"Pong with Text": func() (PacketV4, string, error) {
+		"Pong with Text": func(*testing.T) (PacketV4, string, error) {
 			want := `3probe`
 			data := PacketV4{PacketV3: PacketV3{Packet{T: PongPacket, D: "probe"}, false}}
 			return data, want, nil
 		},
-		"Message": func() (PacketV4, string, error) {
+		"Message": func(*testing.T) (PacketV4, string, error) {
 			want := `4HelloWorld`
 			data := PacketV4{PacketV3: PacketV3{Packet{T: MessagePacket, D: "HelloWorld"}, false}}
 			return data, want, nil
 		},
-		"Message with Binary": func() (PacketV4, string, error) {
+		"Message with Binary": func(*testing.T) (PacketV4, string, error) {
 			want := "4\x00\x01\x02\x03\x04\x05"
 			data := PacketV4{PacketV3: PacketV3{Packet{T: MessagePacket, D: "\x00\x01\x02\x03\x04\x05"}, false}}
 			return data, want, nil
 		},
-		"Upgrade": func() (PacketV4, string, error) {
+		"Upgrade": func(*testing.T) (PacketV4, string, error) {
 			want := `5`
 			data := PacketV4{PacketV3: PacketV3{Packet{T: UpgradePacket, D: nil}, false}}
 			return data, want, nil
 		},
-		"NOOP": func() (PacketV4, string, error) {
+		"NOOP": func(*testing.T) (PacketV4, string, error) {
 			want := `6`
 			data := PacketV4{PacketV3: PacketV3{Packet{T: NoopPacket, D: nil}, false}}
 			return data, want, nil
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }

--- a/engineio/protocol/payload.v2_test.go
+++ b/engineio/protocol/payload.v2_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,65 +10,65 @@ import (
 )
 
 func TestReadPayloadV2(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(string, PayloadV2, error) func(*testing.T){
-		".Decode": func(opts ...testoption) func(string, PayloadV2, error) func(*testing.T) {
-			return func(data string, want PayloadV2, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data string, want PayloadV2, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data string, want PayloadV2, xerr error)
+	)
 
-					var have PayloadV2
-					var err = NewPayloadDecoderV2(strings.NewReader(data)).Decode(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+	runWithOptions := map[string]testParamsInFn{
+		"Decode": func(data string, want PayloadV2, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have PayloadV2
+				var err = NewPayloadDecoderV2(strings.NewReader(data)).Decode(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
-		".ReadPayload": func(opts ...testoption) func(string, PayloadV2, error) func(*testing.T) {
-			return func(data string, want PayloadV2, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var got Payload
-					var pay = _payloadDecoderV2(NewPayloadDecoderV2)
-					var err = pay.From(strings.NewReader(data)).ReadPayload(&got)
-
-					var have = make(PayloadV2, len(got))
-					for i, v := range got {
-						have[i] = PacketV2{v}
-					}
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+		"ReadPayload": func(data string, want PayloadV2, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var got Payload
+				var pay = _payloadDecoderV2(NewPayloadDecoderV2)
+				var err = pay.From(strings.NewReader(data)).ReadPayload(&got)
+
+				var have = make(PayloadV2, len(got))
+				for i, v := range got {
+					have[i] = PacketV2{v}
+				}
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
-		".ReadPayload packet": func(opts ...testoption) func(string, PayloadV2, error) func(*testing.T) {
-			return func(data string, want PayloadV2, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var have Payload
-					var pay = _payloadDecoderV2(NewPayloadDecoderV2)
-					var err = pay.From(strings.NewReader(data)).ReadPayload(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want.PayloadVal(), have)
+		"ReadPayload packet": func(data string, want PayloadV2, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have Payload
+				var pay = _payloadDecoderV2(NewPayloadDecoderV2)
+				var err = pay.From(strings.NewReader(data)).ReadPayload(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want.PayloadVal(), have)
 			}
 		},
 	}
 
-	spec := map[string]func() (string, PayloadV2, error){
-		"Payload": func() (string, PayloadV2, error) {
+	spec := map[string]testParamsOutFn{
+		"Payload": func(*testing.T) (string, PayloadV2, error) {
 			data := `41:0{"sid":"","upgrades":[],"pingTimeout":0}1:16:2probe6:3probe11:4HelloWorld1:51:6`
 			want := PayloadV2{
 				PacketV2{Packet{T: OpenPacket, D: &HandshakeV2{Upgrades: []string{}}}},
@@ -82,68 +83,68 @@ func TestReadPayloadV2(t *testing.T) {
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }
 
 func TestWritePayloadV2(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(PayloadV2, string, error) func(*testing.T){
-		".Encode": func(opts ...testoption) func(PayloadV2, string, error) func(*testing.T) {
-			return func(data PayloadV2, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data PayloadV2, want string, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data PayloadV2, want string, xerr error)
+	)
 
-					var have = new(bytes.Buffer)
-					var err = NewPayloadEncoderV2(have).Encode(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+	runWithOptions := map[string]testParamsInFn{
+		"Encode": func(data PayloadV2, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var err = NewPayloadEncoderV2(have).Encode(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
-		".WritePayload": func(opts ...testoption) func(PayloadV2, string, error) func(*testing.T) {
-			return func(data PayloadV2, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var have = new(bytes.Buffer)
-					var pay = _payloadEncoderV2(NewPayloadEncoderV2)
-					var err = pay.To(have).WritePayload(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+		"WritePayload": func(data PayloadV2, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var pay = _payloadEncoderV2(NewPayloadEncoderV2)
+				var err = pay.To(have).WritePayload(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
-		".WritePayload packet": func(opts ...testoption) func(PayloadV2, string, error) func(*testing.T) {
-			return func(data PayloadV2, want string, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var have = new(bytes.Buffer)
-					var pay = _payloadEncoderV2(NewPayloadEncoderV2)
-					var err = pay.To(have).WritePayload(data.PayloadVal())
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+		"WritePayload packet": func(data PayloadV2, want string, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var pay = _payloadEncoderV2(NewPayloadEncoderV2)
+				var err = pay.To(have).WritePayload(data.PayloadVal())
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
 	}
 
-	spec := map[string]func() (PayloadV2, string, error){
-		"Payload": func() (PayloadV2, string, error) {
+	spec := map[string]testParamsOutFn{
+		"Payload": func(*testing.T) (PayloadV2, string, error) {
 			want := `41:0{"sid":"","upgrades":[],"pingTimeout":0}1:16:2probe6:3probe11:4HelloWorld1:51:6`
 			data := PayloadV2{
 				PacketV2{Packet{T: OpenPacket, D: &HandshakeV2{}}},
@@ -158,9 +159,9 @@ func TestWritePayloadV2(t *testing.T) {
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }

--- a/engineio/protocol/payload.v3_test.go
+++ b/engineio/protocol/payload.v3_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,184 +10,188 @@ import (
 )
 
 func TestReadPayloadV3(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(string, PayloadV3, bool, error) func(*testing.T){
-		".Decode": func(opts ...testoption) func(string, PayloadV3, bool, error) func(*testing.T) {
-			return func(data string, want PayloadV3, isXHR2 bool, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data string, want PayloadV3, hasBinaryClient bool, hasXHR2Client bool, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data string, want PayloadV3, hasBinaryClient bool, hasXHR2Client bool, xerr error)
+	)
 
-					var have PayloadV3
-					var dec = NewPayloadDecoderV3(strings.NewReader(data))
-					dec.IsXHR2 = isXHR2
-					var err = dec.Decode(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+	runWithOptions := map[string]testParamsInFn{
+		"Decode": func(data string, want PayloadV3, hasBinaryClient bool, hasXHR2Client bool, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have PayloadV3
+				var dec = NewPayloadDecoderV3(strings.NewReader(data))
+				dec.hasBinarySupport = hasBinaryClient
+				dec.hasXHR2Support = hasXHR2Client
+				var err = dec.Decode(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
-		".ReadPayload": func(opts ...testoption) func(string, PayloadV3, bool, error) func(*testing.T) {
-			return func(data string, want PayloadV3, isXHR2 bool, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var have PayloadV3
-					var err = NewPayloadDecoderV3.SetXHR2(isXHR2).From(strings.NewReader(data)).ReadPayload(&have)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have)
+		"ReadPayload": func(data string, want PayloadV3, hasBinaryClient bool, hasXHR2Client bool, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have PayloadV3
+				var err = NewPayloadDecoderV3.SetBinary(hasBinaryClient).SetXHR2(hasXHR2Client).From(strings.NewReader(data)).ReadPayload(&have)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have)
 			}
 		},
 	}
 
-	spec := map[string]func() (string, PayloadV3, bool, error){
-		"Without Binary": func() (string, PayloadV3, bool, error) {
-			isBinary, isXHR2 := false, false
+	spec := map[string]testParamsOutFn{
+		"Without Binary": func(*testing.T) (string, PayloadV3, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := false, false
 			data := `6:4hello2:4€`
 			want := PayloadV3{
-				{Packet{T: MessagePacket, D: "hello"}, isBinary},
-				{Packet{T: MessagePacket, D: "€"}, isBinary},
+				{Packet{T: MessagePacket, D: "hello"}, false},
+				{Packet{T: MessagePacket, D: "€"}, false},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
-		"Without Binary and Supported": func() (string, PayloadV3, bool, error) {
-			isBinary, isXHR2 := false, true
+		"Without Binary and Supported": func(*testing.T) (string, PayloadV3, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := false, true
 			data := `6:4hello2:4€`
 			want := PayloadV3{
-				{Packet{T: MessagePacket, D: "hello"}, isBinary},
-				{Packet{T: MessagePacket, D: "€"}, isBinary},
+				{Packet{T: MessagePacket, D: "hello"}, false},
+				{Packet{T: MessagePacket, D: "€"}, false},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
-		"With Binary and Supported": func() (string, PayloadV3, bool, error) {
-			isBinary, isXHR2 := true, true
+		"With Binary and Supported": func(*testing.T) (string, PayloadV3, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := true, true
 			data := string([]byte{0x00, 0x04, 0xff, 0x34, 0xe2, 0x82, 0xac, 0x01, 0x04, 0xff, 0x01, 0x02, 0x03, 0x04})
 			want := PayloadV3{
 				{Packet{T: MessagePacket, D: "€"}, false},
-				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, isBinary},
+				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, true},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
-		"With Binary and Not Supported": func() (string, PayloadV3, bool, error) {
-			isBinary, isXHR2 := true, false
+		"With Binary and Not Supported": func(*testing.T) (string, PayloadV3, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := true, false
 			data := `2:4€10:b4AQIDBA==`
 			want := PayloadV3{
 				{Packet{T: MessagePacket, D: "€"}, false},
-				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, isBinary},
+				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, true},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }
 
 func TestWritePayloadV3(t *testing.T) {
-	var opts []testoption
+	var opts = []func(*testing.T){}
 
-	runWithOptions := map[string]func(opts ...testoption) func(PayloadV3, string, bool, error) func(*testing.T){
-		".Encode": func(opts ...testoption) func(PayloadV3, string, bool, error) func(*testing.T) {
-			return func(data PayloadV3, want string, isXHR2 bool, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(data PayloadV3, want string, hasBinaryClient bool, hasXHR2Client bool, xerr error) testFn
+		testParamsOutFn func(*testing.T) (data PayloadV3, want string, hasBinaryClient bool, hasXHR2Client bool, xerr error)
+	)
 
-					var have = new(bytes.Buffer)
-					var enc = NewPayloadEncoderV3(have)
-					enc.IsXHR2 = isXHR2
-					var err = enc.Encode(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+	runWithOptions := map[string]testParamsInFn{
+		"Encode": func(data PayloadV3, want string, hasBinaryClient bool, hasXHR2Client bool, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var enc = NewPayloadEncoderV3(have)
+				enc.hasBinarySupport = hasBinaryClient
+				enc.hasXHR2Support = hasXHR2Client
+				var err = enc.Encode(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
-		".WritePayload": func(opts ...testoption) func(PayloadV3, string, bool, error) func(*testing.T) {
-			return func(data PayloadV3, want string, isXHR2 bool, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var have = new(bytes.Buffer)
-					var err = NewPayloadEncoderV3.SetXHR2(isXHR2).To(have).WritePayload(data)
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+		"WritePayload": func(data PayloadV3, want string, hasBinaryClient bool, hasXHR2Client bool, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var err = NewPayloadEncoderV3.SetBinary(hasBinaryClient).SetXHR2(hasXHR2Client).To(have).WritePayload(data)
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
-		".WritePayload packet": func(opts ...testoption) func(PayloadV3, string, bool, error) func(*testing.T) {
-			return func(data PayloadV3, want string, isXHR2 bool, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var have = new(bytes.Buffer)
-					var err = NewPayloadEncoderV3.SetXHR2(isXHR2).To(have).WritePayload(data.PayloadVal())
-
-					assert.ErrorIs(t, err, xerr)
-					assert.Equal(t, want, have.String())
+		"WritePayload packet": func(data PayloadV3, want string, hasBinaryClient bool, hasXHR2Client bool, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				var err = NewPayloadEncoderV3.SetBinary(hasBinaryClient).SetXHR2(hasXHR2Client).To(have).WritePayload(data.PayloadVal())
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, want, have.String())
 			}
 		},
 	}
 
-	spec := map[string]func() (PayloadV3, string, bool, error){
-		"Without Binary": func() (PayloadV3, string, bool, error) {
-			isBinary, isXHR2 := false, false
+	spec := map[string]testParamsOutFn{
+		"Without Binary": func(*testing.T) (PayloadV3, string, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := false, false
 			want := `6:4hello2:4€`
 			data := PayloadV3{
-				{Packet{T: MessagePacket, D: "hello"}, isBinary},
-				{Packet{T: MessagePacket, D: "€"}, isBinary},
+				{Packet{T: MessagePacket, D: "hello"}, false},
+				{Packet{T: MessagePacket, D: "€"}, false},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
-		"Without Binary and Supported": func() (PayloadV3, string, bool, error) {
-			isBinary, isXHR2 := false, true
+		"Without Binary and Supported": func(*testing.T) (PayloadV3, string, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := false, true
 			want := `6:4hello2:4€`
 			data := PayloadV3{
-				{Packet{T: MessagePacket, D: "hello"}, isBinary},
-				{Packet{T: MessagePacket, D: "€"}, isBinary},
+				{Packet{T: MessagePacket, D: "hello"}, false},
+				{Packet{T: MessagePacket, D: "€"}, false},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
-		"With Binary and Supported": func() (PayloadV3, string, bool, error) {
-			isBinary, isXHR2 := true, true
+		"With Binary and Supported": func(*testing.T) (PayloadV3, string, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := true, true
 			want := string([]byte{0x00, 0x04, 0xff, 0x34, 0xe2, 0x82, 0xac, 0x01, 0x04, 0xff, 0x01, 0x02, 0x03, 0x04})
 			data := PayloadV3{
-				{Packet{T: MessagePacket, D: "€"}, isBinary},
-				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, isBinary},
+				{Packet{T: MessagePacket, D: "€"}, false},
+				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, true},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
-		"With Binary and Not Supported": func() (PayloadV3, string, bool, error) {
-			isBinary, isXHR2 := true, false
+		"With Binary and Not Supported": func(*testing.T) (PayloadV3, string, bool, bool, error) {
+			hasBinaryClient, hasXHR2Client := true, false
 			want := `2:4€10:b4AQIDBA==`
 			data := PayloadV3{
-				{Packet{T: MessagePacket, D: "€"}, isBinary},
-				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, isBinary},
+				{Packet{T: MessagePacket, D: "€"}, false},
+				{Packet{T: MessagePacket, D: bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04})}, true},
 			}
-			return data, want, isXHR2, nil
+			return data, want, hasBinaryClient, hasXHR2Client, nil
 		},
 	}
 
-	for name, testing := range spec {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }

--- a/engineio/protocol/utility_test.go
+++ b/engineio/protocol/utility_test.go
@@ -1,0 +1,71 @@
+package protocol
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimitRuneReader(t *testing.T) {
+	var opts = []func(*testing.T){}
+
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(io.Reader, int64, string, int64, error) testFn
+		testParamsOutFn func(*testing.T) (io.Reader, int64, string, int64, error)
+	)
+
+	runWithOptions := map[string]testParamsInFn{
+		"Basic": func(r io.Reader, limit int64, out string, chars int64, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
+				}
+
+				buf := new(bytes.Buffer)
+				n, err := buf.ReadFrom(LimitRuneReader(r, limit))
+
+				assert.ErrorIs(t, err, xerr)
+				assert.Equal(t, out, buf.String())
+				assert.Equal(t, chars, n)
+			}
+		},
+	}
+
+	tests := map[string]testParamsOutFn{
+		"Standard": func(t *testing.T) (r io.Reader, limit int64, out string, chars int64, xerr error) {
+			return strings.NewReader("0123456789"), 5, "01234", 5, nil
+		},
+		"Unicode": func(t *testing.T) (r io.Reader, limit int64, out string, chars int64, xerr error) {
+			// int64(len([]byte("åß∂ƒ©"))) = 11
+			return strings.NewReader("åß∂ƒ©˙∆˚¬…æ"), 5, "åß∂ƒ©", 11, nil
+		},
+		"mixed": func(t *testing.T) (r io.Reader, limit int64, out string, chars int64, xerr error) {
+			// int64(len([]byte("åß∂ƒ©"))) = 11
+			return strings.NewReader("å1ß2∂3ƒ4©5˙6∆7˚8¬9…0æ"), 5, "å1ß2∂", 9, nil
+		},
+	}
+
+	for name, testParams := range tests {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
+		}
+	}
+}
+
+func FuzzLimitRuneReader(f *testing.F) {
+	f.Add("1234", int64(5))
+	f.Add("åß∂ƒ©˙∆˚¬…æ", int64(3))
+	f.Fuzz(func(t *testing.T, in string, n int64) {
+		buf := new(bytes.Buffer)
+		j, err := buf.ReadFrom(LimitRuneReader(strings.NewReader(in), n))
+		assert.Equal(t, string([]rune(in)[:n]), buf.String())
+		if err != nil {
+			t.Errorf("bad: %q %d", buf.String(), j)
+		}
+	})
+}

--- a/engineio/server.v2_test.go
+++ b/engineio/server.v2_test.go
@@ -1,7 +1,78 @@
-package engineio
+package engineio_test
 
-import "testing"
+import (
+	"fmt"
+	"testing"
 
-func TestServerV2Basic(t *testing.T) {
-	// blank...
+	"github.com/njones/socketio"
+	"github.com/njones/socketio/engineio"
+)
+
+// CORS
+// XHR2
+
+type (
+	testFn          func(*testing.T)
+	testParamsInFn  func(engineio.Server) testFn
+	testParamsOutFn func(*testing.T) engineio.Server
+)
+
+func TestServerV2(t *testing.T) {
+	var opts = []func(*testing.T){}
+	var EIOv = 3
+
+	runWithOptions := map[string]testParamsInFn{
+		"cors": func(v2 engineio.Server) testFn {
+			return CORSTestV2(opts, EIOv, v2)
+		},
+	}
+
+	tests := map[string]testParamsOutFn{
+		"sending to the client": SendingToTheClientV2,
+	}
+
+	for name, testParams := range tests {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
+		}
+	}
+
+}
+
+func CORSTestV2(opts []func(*testing.T), EIOv int, v2 engineio.Server) testFn {
+	return func(t *testing.T) {
+		for _, opt := range opts {
+			opt(t)
+		}
+	}
+}
+
+func SendingToTheClientV2(t *testing.T) (a socketio.Server) {
+	// 	var (
+	// 		v2   = socketio.NewServerV2(testingQuickPoll)
+	// 		wait = new(sync.WaitGroup)
+
+	// 		want = map[string][][]string{
+	// 			"grab1": {
+	// 				{`42["hello","can you hear me?",1,2,"abc"]`},
+	// 				{`42["hello","can you hear me?",1,2,"abc"]`},
+	// 				{`42["hello","can you hear me?",1,2,"abc"]`},
+	// 			},
+	// 		}
+	// 		count = len(want["grab1"])
+
+	// 		str = serialize.String
+	// 		one = serialize.Int(1)
+	// 	)
+
+	// 	wait.Add(count)
+	// 	v2.OnConnect(func(socket *socketio.SocketV2) error {
+	// 		defer wait.Done()
+
+	// 		socket.Emit("hello", str("can you hear me?"), one, serialize.Int(2), str("abc"))
+	// 		return nil
+	// 	})
+
+	// 	return v2, count, want, wait
+	return
 }

--- a/engineio/server.v3_test.go
+++ b/engineio/server.v3_test.go
@@ -1,0 +1,24 @@
+package engineio
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectionServerV3(t *testing.T) {
+	v3 := NewServerV3()
+
+	server := httptest.NewServer(v3)
+	client := http.DefaultClient
+	urlStr := fmt.Sprintf("%s/engine.io/?EIO=3&transport=polling&t=%d", server.URL, time.Now().UnixNano())
+
+	resp, err := client.Get(urlStr)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+}

--- a/engineio/transport/transport.polling_test.go
+++ b/engineio/transport/transport.polling_test.go
@@ -1,80 +1,217 @@
 package transport
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	eiop "github.com/njones/socketio/engineio/protocol"
+	itest "github.com/njones/socketio/internal/test"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPollingTransportReceive(t *testing.T) {
-	cV2 := Codec{
-		PacketEncoder:  eiop.NewPacketEncoderV2,
-		PacketDecoder:  eiop.NewPacketDecoderV2,
-		PayloadEncoder: eiop.NewPayloadEncoderV2,
-		PayloadDecoder: eiop.NewPayloadDecoderV2,
-	}
+var runTest = itest.RunTest
 
-	var tests = []struct {
-		name   string
-		data   string
-		packet eiop.Packet
-		codec  Codec
-	}{
-		{
-			name:   "[message]",
-			data:   "6:4Hello",
-			packet: eiop.Packet{T: eiop.MessagePacket, D: "Hello"},
-			codec:  cV2,
+func TestPollingTransport(t *testing.T) {
+	var opts = []func(*testing.T){}
+
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func([]eiop.Packet, string, Codec) testFn
+		testParamsOutFn func(*testing.T) ([]eiop.Packet, string, Codec)
+	)
+
+	runWithOptions := map[string]testParamsInFn{
+		"Send": func(packets []eiop.Packet, message string, codec Codec) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
+				}
+
+				tr := NewPollingTransport(1000, 10*time.Millisecond)(SessionID("12345"), codec)
+
+				for _, packet := range packets {
+					tr.Send(packet)
+				}
+
+				r := httptest.NewRequest("GET", "http://example.com", nil)
+				w := httptest.NewRecorder()
+
+				err := tr.Run(w, r)
+				assert.NoError(t, err)
+
+				have := w.Body.String()
+				want := message
+
+				assert.Equal(t, want, have)
+			}
+		},
+		"Receive": func(packets []eiop.Packet, message string, codec Codec) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
+				}
+
+				tr := NewPollingTransport(1000, 10*time.Millisecond)(SessionID("12345"), codec)
+
+				r := httptest.NewRequest("POST", "http://example.com", strings.NewReader(message))
+				w := httptest.NewRecorder()
+
+				err := tr.Run(w, r)
+				assert.NoError(t, err)
+
+				var n int
+				for have := range tr.Receive() {
+					if len(packets) == n {
+						// we send back a close socket internally
+						assert.Equal(t, eiop.Packet{T: eiop.NoopPacket, D: socketClose{}}, have)
+						break
+					}
+					want := packets[n]
+					if want.T != eiop.NoopPacket {
+						assert.Equal(t, want, have)
+					}
+					n++
+				}
+			}
 		},
 	}
 
-	for _, test := range tests {
+	spec := map[string]testParamsOutFn{
+		"Version 2 Single": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV2,
+				PacketDecoder:  eiop.NewPacketDecoderV2,
+				PayloadEncoder: eiop.NewPayloadEncoderV2,
+				PayloadDecoder: eiop.NewPayloadDecoderV2,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: "Hello"}}, "6:4Hello", cV2
+		},
+		"Version 2 Payload": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV2,
+				PacketDecoder:  eiop.NewPacketDecoderV2,
+				PayloadEncoder: eiop.NewPayloadEncoderV2,
+				PayloadDecoder: eiop.NewPayloadDecoderV2,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: "Hello"}, {T: eiop.MessagePacket, D: "World"}}, "6:4Hello6:4World", cV2
+		},
+		"Version 3 Single": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV3,
+				PacketDecoder:  eiop.NewPacketDecoderV3,
+				PayloadEncoder: eiop.NewPayloadEncoderV3,
+				PayloadDecoder: eiop.NewPayloadDecoderV3,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: "Hello"}}, "6:4Hello", cV2
+		},
+		"Version 4 Single": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV4,
+				PacketDecoder:  eiop.NewPacketDecoderV4,
+				PayloadEncoder: eiop.NewPayloadEncoderV4,
+				PayloadDecoder: eiop.NewPayloadDecoderV4,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: "Hello"}}, "4Hello", cV2
+		},
+		"Version 4 Payload": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV4,
+				PacketDecoder:  eiop.NewPacketDecoderV4,
+				PayloadEncoder: eiop.NewPayloadEncoderV4,
+				PayloadDecoder: eiop.NewPayloadDecoderV4,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: "Hello"}, {T: eiop.MessagePacket, D: "World"}}, "4Hello\x1e4World", cV2
+		},
+	}
 
-		tr := NewPollingTransport(1000, 10*time.Millisecond)(SessionID("12345"), test.codec)
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
+		}
+	}
+}
 
-		// Receive Test
-		t.Run(test.name, func(t2 *testing.T) {
-			q := new(sync.WaitGroup)
-			h := make(chan eiop.Packet, 1)
+func TestPollingJSONPTransport(t *testing.T) {
+	var opts = []func(*testing.T){}
 
-			q.Add(1)
-			go func() {
-				defer q.Done()
-				h <- <-tr.Receive()
-			}()
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func([]eiop.Packet, string, Codec) testFn
+		testParamsOutFn func(*testing.T) ([]eiop.Packet, string, Codec)
+	)
 
-			r := httptest.NewRequest("POST", "http://example.com", strings.NewReader(test.data))
-			w := httptest.NewRecorder()
+	runWithOptions := map[string]testParamsInFn{
+		"JSONP": func(packets []eiop.Packet, message string, codec Codec) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
+				}
 
-			err := tr.Run(w, r)
-			assert.NoError(t, err)
-			q.Wait()
+				tr := NewPollingTransport(1000, 10*time.Millisecond)(SessionID("12345"), codec)
 
-			have := <-h
-			want := test.packet
+				for _, packet := range packets {
+					tr.Send(packet)
+				}
 
-			assert.Equal(t, want, have)
-		})
+				r := httptest.NewRequest("GET", "http://example.com?j=10", nil)
+				w := httptest.NewRecorder()
 
-		// Send Test
-		t.Run(test.name, func(t2 *testing.T) {
-			tr.Send(test.packet)
+				err := tr.Run(w, r)
+				assert.NoError(t, err)
 
-			r := httptest.NewRequest("GET", "http://example.com", nil)
-			w := httptest.NewRecorder()
+				have := w.Body.String()
+				want := message
 
-			err := tr.Run(w, r)
-			assert.NoError(t, err)
+				assert.Equal(t, want, have)
+			}
+		},
+	}
 
-			have := w.Body.String()
-			want := test.data
+	spec := map[string]testParamsOutFn{
+		"No Quotes": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV2,
+				PacketDecoder:  eiop.NewPacketDecoderV2,
+				PayloadEncoder: eiop.NewPayloadEncoderV2,
+				PayloadDecoder: eiop.NewPayloadDecoderV2,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: "Hello World"}}, `___eio[10]("12:4Hello World");`, cV2
+		},
+		"With Quotes": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV2,
+				PacketDecoder:  eiop.NewPacketDecoderV2,
+				PayloadEncoder: eiop.NewPayloadEncoderV2,
+				PayloadDecoder: eiop.NewPayloadDecoderV2,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: `"Hello World"`}}, `___eio[10]("14:4\"Hello World\"");`, cV2
+		},
+		"With Quotes in Quotes": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV2,
+				PacketDecoder:  eiop.NewPacketDecoderV2,
+				PayloadEncoder: eiop.NewPayloadEncoderV2,
+				PayloadDecoder: eiop.NewPayloadDecoderV2,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: `""Hello World""`}}, `___eio[10]("16:4\"\"Hello World\"\"");`, cV2
+		},
+		"Binary": func(*testing.T) (packet []eiop.Packet, message string, codec Codec) {
+			cV2 := Codec{
+				PacketEncoder:  eiop.NewPacketEncoderV2,
+				PacketDecoder:  eiop.NewPacketDecoderV2,
+				PayloadEncoder: eiop.NewPayloadEncoderV2,
+				PayloadDecoder: eiop.NewPayloadDecoderV2,
+			}
+			return []eiop.Packet{{T: eiop.MessagePacket, D: []byte{0x01, 0x02, 0x03, 0x04}}}, `___eio[10]("5:4\x01\x02\x03\x04");`, cV2
+		},
+	}
 
-			assert.Equal(t, want, have)
-		})
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
+		}
 	}
 }

--- a/internal/test/runner.go
+++ b/internal/test/runner.go
@@ -1,0 +1,53 @@
+package itest
+
+import (
+	"strings"
+	"testing"
+)
+
+func RunTest(testNames ...string) func(*testing.T) {
+	var subTestName = strings.NewReplacer(" ", "_")
+
+	return func(t *testing.T) {
+		t.Helper()
+
+		have := strings.SplitN(t.Name(), "/", 2)[1]
+		suffix := strings.Split(have, ".")[1]
+
+		for _, testName := range testNames {
+			if testName == "" || testName == "*" {
+				return
+			}
+
+			want := subTestName.Replace(testName)
+			if !strings.Contains(want, ".") {
+				want += "." + suffix
+			}
+			if have == want {
+				return
+			}
+		}
+		t.SkipNow()
+	}
+}
+
+func SkipTest(testNames ...string) func(*testing.T) {
+	var subTestName = strings.NewReplacer(" ", "_")
+
+	return func(t *testing.T) {
+		t.Helper()
+
+		have := strings.SplitN(t.Name(), "/", 2)[1]
+		suffix := strings.Split(have, ".")[1]
+
+		for _, testName := range testNames {
+			want := subTestName.Replace(testName)
+			if !strings.Contains(want, ".") {
+				want += "." + suffix
+			}
+			if have == want {
+				t.SkipNow()
+			}
+		}
+	}
+}

--- a/protocol/packet.v2_test.go
+++ b/protocol/packet.v2_test.go
@@ -2,86 +2,74 @@ package protocol
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-type testReadV2 func(PacketV2, []byte, error) func(*testing.T)
-type testWriteV2 func([]byte, PacketV2, error) func(*testing.T)
-
-func mergeReadV2(dst, src map[string]func() (PacketV2, []byte, error)) {
-	for k, v := range src {
-		dst[k] = v
-	}
-}
-
-func mergeWriteV2(dst, src map[string]func() ([]byte, PacketV2, error)) {
-	for k, v := range src {
-		dst[k] = v
-	}
-}
-
 func TestPacketV2Read(t *testing.T) {
-	var opts = []testoption{}
+	var opts = []func(*testing.T){}
 
-	testchecks := map[string]func(checks ...testoption) testReadV2{
-		".ReadFrom": func(checks ...testoption) testReadV2 {
-			return func(pac PacketV2, want []byte, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, check := range checks {
-						check(t)
-					}
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(pac PacketV2, want []byte, xerr error) testFn
+		testParamsOutFn func(*testing.T) (pac PacketV2, want []byte, xerr error)
+	)
 
-					var have = new(bytes.Buffer)
-					n, err := have.ReadFrom(&pac)
-					assert.Equal(t, int64(len(want)), n)
-					assert.Equal(t, xerr, err)
-
-					assert.Equal(t, want, have.Bytes())
+	runWithOptions := map[string]testParamsInFn{
+		"ReadFrom": func(pac PacketV2, want []byte, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				n, err := have.ReadFrom(&pac)
+				assert.Equal(t, int64(len(want)), n)
+				assert.Equal(t, xerr, err)
+
+				assert.Equal(t, want, have.Bytes())
 			}
 		},
-		".WriteTo": func(checks ...testoption) testReadV2 {
-			return func(pac PacketV2, want []byte, xerr error) func(*testing.T) {
-				return func(t *testing.T) {
-					for _, check := range checks {
-						check(t)
-					}
-
-					var have = new(bytes.Buffer)
-					n, err := (&pac).WriteTo(have)
-					assert.Equal(t, int64(len(want)), n)
-					assert.Equal(t, xerr, err)
-
-					assert.Equal(t, want, have.Bytes())
+		"WriteTo": func(pac PacketV2, want []byte, xerr error) testFn {
+			return func(t *testing.T) {
+				for _, opt := range opts {
+					opt(t)
 				}
+
+				var have = new(bytes.Buffer)
+				n, err := (&pac).WriteTo(have)
+				assert.Equal(t, int64(len(want)), n)
+				assert.Equal(t, xerr, err)
+
+				assert.Equal(t, want, have.Bytes())
 			}
 		},
 	}
 
-	spec := map[string]func() (PacketV2, []byte, error){
-		"CONNECT": func() (PacketV2, []byte, error) {
+	spec := map[string]testParamsOutFn{
+		"CONNECT": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`0`)
 			data := *NewPacketV2().(*PacketV2)
 			return data, want, nil
 		},
-		"DISCONNECT": func() (PacketV2, []byte, error) {
+		"DISCONNECT": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`1/admin`)
 			data := *NewPacketV2().
 				WithType(DisconnectPacket.Byte()).
 				WithNamespace("/admin").(*PacketV2)
 			return data, want, nil
 		},
-		"EVENT": func() (PacketV2, []byte, error) {
+		"EVENT": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`2["hello",1]`)
 			data := *NewPacketV2().
 				WithType(EventPacket.Byte()).
 				WithData([]interface{}{"hello", 1.0}).(*PacketV2)
 			return data, want, nil
 		},
-		"EVENT with AckID": func() (PacketV2, []byte, error) {
+		"EVENT with AckID": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`2/admin,456["project:delete",123]`)
 			data := *NewPacketV2().
 				WithNamespace("/admin").
@@ -90,7 +78,7 @@ func TestPacketV2Read(t *testing.T) {
 				WithAckID(456).(*PacketV2)
 			return data, want, nil
 		},
-		"ACK": func() (PacketV2, []byte, error) {
+		"ACK": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`3/admin,456[]`)
 			data := *NewPacketV2().
 				WithNamespace("/admin").
@@ -99,7 +87,7 @@ func TestPacketV2Read(t *testing.T) {
 				WithAckID(456).(*PacketV2)
 			return data, want, nil
 		},
-		"ERROR": func() (PacketV2, []byte, error) {
+		"ERROR": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`4/admin,"Not authorized"`)
 			data := *NewPacketV2().
 				WithNamespace("/admin").
@@ -107,14 +95,14 @@ func TestPacketV2Read(t *testing.T) {
 				WithData(&notAuthorized).(*PacketV2)
 			return data, want, nil
 		},
-		"BINARY EVENT": func() (PacketV2, []byte, error) {
+		"BINARY EVENT": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`51-["hello",{"base64":true,"data":"xAMBAgM="}]`)
 			data := *NewPacketV2().
 				WithType(BinaryEventPacket.Byte()).
 				WithData([]interface{}{"hello", bytes.NewReader([]byte{0x01, 0x02, 0x03})}).(*PacketV2)
 			return data, want, nil
 		},
-		"BINARY EVENT with AckID": func() (PacketV2, []byte, error) {
+		"BINARY EVENT with AckID": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`51-/admin,456["hello",{"base64":true,"data":"xAMBAgM="}]`)
 			data := *NewPacketV2().
 				WithType(BinaryEventPacket.Byte()).
@@ -123,22 +111,21 @@ func TestPacketV2Read(t *testing.T) {
 				WithAckID(456).(*PacketV2)
 			return data, want, nil
 		},
-	}
 
-	extra := map[string]func() (PacketV2, []byte, error){
-		"CONNECT /admin ns": func() (PacketV2, []byte, error) {
+		// extra
+		"CONNECT /admin ns": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`0/admin`)
 			data := *NewPacketV2().
 				WithNamespace("/admin").(*PacketV2)
 			return data, want, nil
 		},
-		"CONNECT /admin ns and extra info": func() (PacketV2, []byte, error) {
+		"CONNECT /admin ns and extra info": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`0/admin?token=1234&uid=abcd`)
 			data := *NewPacketV2().
 				WithNamespace("/admin?token=1234&uid=abcd").(*PacketV2)
 			return data, want, nil
 		},
-		"EVENT with Binary": func() (PacketV2, []byte, error) {
+		"EVENT with Binary": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`21-["name",{"base64":true,"data":"xAtiaW5hcnkgZGF0YQ=="}]`)
 			data := *NewPacketV2().
 				WithType(EventPacket.Byte()).
@@ -146,7 +133,7 @@ func TestPacketV2Read(t *testing.T) {
 				WithData([]interface{}{"name", strings.NewReader("binary data")}).(*PacketV2)
 			return data, want, nil
 		},
-		"ACK with Object": func() (PacketV2, []byte, error) {
+		"ACK with Object": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`3/site,444{"api-mocked.com":"member"}`)
 			data := *NewPacketV2().
 				WithNamespace("/site").
@@ -155,7 +142,7 @@ func TestPacketV2Read(t *testing.T) {
 				WithAckID(444).(*PacketV2)
 			return data, want, nil
 		},
-		"ACK with Object and Binary": func() (PacketV2, []byte, error) {
+		"ACK with Object and Binary": func(*testing.T) (PacketV2, []byte, error) {
 			want := []byte(`31-/site,444{"api-mocked.com":{"base64":true,"data":"xAtiaW5hcnkgZGF0YQ=="}}`)
 			data := *NewPacketV2().
 				WithNamespace("/site").
@@ -166,22 +153,27 @@ func TestPacketV2Read(t *testing.T) {
 		},
 	}
 
-	mergeReadV2(extra, spec)
-	for name, testing := range extra {
-		for fill, testcheck := range testchecks {
-			t.Run(name+fill, testcheck(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 }
 
 func TestWritePacketV2(t *testing.T) {
-	var opts = []testoption{}
+	var opts = []func(*testing.T){}
 
-	testcheck := func(checks ...testoption) testWriteV2 {
-		return func(data []byte, want PacketV2, xerr error) func(*testing.T) {
+	type (
+		testFn          func(*testing.T)
+		testParamsInFn  func(want []byte, pac PacketV2, xerr error) testFn
+		testParamsOutFn func(*testing.T) (want []byte, pac PacketV2, xerr error)
+	)
+
+	runWithOptions := map[string]testParamsInFn{
+		"Write": func(data []byte, want PacketV2, xerr error) testFn {
 			return func(t *testing.T) {
-				for _, check := range checks {
-					check(t)
+				for _, opt := range opts {
+					opt(t)
 				}
 
 				var have PacketV2
@@ -202,23 +194,23 @@ func TestWritePacketV2(t *testing.T) {
 					}
 				}
 			}
-		}
+		},
 	}
 
-	spec := map[string]func() ([]byte, PacketV2, error){
-		"CONNECT": func() ([]byte, PacketV2, error) {
+	spec := map[string]testParamsOutFn{
+		"CONNECT": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`0`)
 			want := *NewPacketV2().WithNamespace("/").(*PacketV2)
 			return data, want, nil
 		},
-		"DISCONNECT": func() ([]byte, PacketV2, error) {
+		"DISCONNECT": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`1`)
 			want := *NewPacketV2().
 				WithType(DisconnectPacket.Byte()).
 				WithNamespace("/").(*PacketV2)
 			return data, want, nil
 		},
-		"EVENT": func() ([]byte, PacketV2, error) {
+		"EVENT": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`2["hello",1]`)
 			want := *NewPacketV2().
 				WithType(EventPacket.Byte()).
@@ -226,7 +218,7 @@ func TestWritePacketV2(t *testing.T) {
 				WithData([]interface{}{"hello", 1.0}).(*PacketV2)
 			return data, want, nil
 		},
-		"EVENT with AckID": func() ([]byte, PacketV2, error) {
+		"EVENT with AckID": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`2/admin,456["project:delete",123]`)
 			want := *NewPacketV2().
 				WithType(EventPacket.Byte()).
@@ -235,7 +227,7 @@ func TestWritePacketV2(t *testing.T) {
 				WithAckID(456).(*PacketV2)
 			return data, want, nil
 		},
-		"ACK": func() ([]byte, PacketV2, error) {
+		"ACK": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`3/admin,456[]`)
 			want := *NewPacketV2().
 				WithType(AckPacket.Byte()).
@@ -244,7 +236,7 @@ func TestWritePacketV2(t *testing.T) {
 				WithAckID(456).(*PacketV2)
 			return data, want, nil
 		},
-		"ERROR": func() ([]byte, PacketV2, error) {
+		"ERROR": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`4/admin,"Not authorized"`)
 			want := *NewPacketV2().
 				WithType(ErrorPacket.Byte()).
@@ -252,7 +244,7 @@ func TestWritePacketV2(t *testing.T) {
 				WithData(notAuthorized).(*PacketV2)
 			return data, want, nil
 		},
-		"BINARY EVENT": func() ([]byte, PacketV2, error) {
+		"BINARY EVENT": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`51-["hello",{"base64":true,"data":"xAMBAgM="}]`)
 			want := *NewPacketV2().
 				WithType(BinaryEventPacket.Byte()).
@@ -260,7 +252,7 @@ func TestWritePacketV2(t *testing.T) {
 				WithData([]interface{}{"hello", bytes.NewReader([]byte{0x01, 0x02, 0x03})}).(*PacketV2)
 			return data, want, nil
 		},
-		"BINARY EVENT with AckID": func() ([]byte, PacketV2, error) {
+		"BINARY EVENT with AckID": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`51-/admin,456["hello",{"base64":true,"data":"xAMBAgM="}]`)
 			want := *NewPacketV2().
 				WithType(BinaryEventPacket.Byte()).
@@ -269,7 +261,7 @@ func TestWritePacketV2(t *testing.T) {
 				WithData([]interface{}{"hello", bytes.NewReader([]byte{0x01, 0x02, 0x03})}).(*PacketV2)
 			return data, want, nil
 		},
-		"ACK with Object": func() ([]byte, PacketV2, error) {
+		"ACK with Object": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`3/site,444{"api-mocked.com":"member"}`)
 			want := *NewPacketV2().
 				WithNamespace("/site").
@@ -278,7 +270,7 @@ func TestWritePacketV2(t *testing.T) {
 				WithAckID(444).(*PacketV2)
 			return data, want, nil
 		},
-		"ACK with Object and Binary": func() ([]byte, PacketV2, error) {
+		"ACK with Object and Binary": func(*testing.T) ([]byte, PacketV2, error) {
 			data := []byte(`31-/site,444{"api-mocked.com":{"base64":true,"data":"xAtiaW5hcnkgZGF0YQ=="}}`)
 			want := *NewPacketV2().
 				WithNamespace("/site").
@@ -289,11 +281,9 @@ func TestWritePacketV2(t *testing.T) {
 		},
 	}
 
-	extra := map[string]func() ([]byte, PacketV2, error){}
-
-	mergeWriteV2(extra, spec)
-
-	for name, testing := range extra {
-		t.Run(name, testcheck(opts...)(testing()))
+	for name, testParams := range spec {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
+		}
 	}
 }

--- a/serialize/serialize_test.go
+++ b/serialize/serialize_test.go
@@ -1,0 +1,233 @@
+package serialize
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func ExampleSerializable_assignment() {
+	// Serialized values can be assigned to a variable before being used
+
+	var e = Error(fmt.Errorf("some bad thing"))
+	var f = Float64(1.4)
+	var i = Integer(10)
+	var s = String("string")
+	var u = Uinteger(11)
+
+	fmt.Printf("Error: %v\nFloat: %f\nInt: %d\nString: %q\nUint: %d\n", e, f.Interface(), i.Interface(), s, u.Interface())
+
+	// Output:
+	// Error: some bad thing
+	// Float: 1.400000
+	// Int: 10
+	// String: "string"
+	// Uint: 11
+}
+
+func ExampleSerializable_short_func() {
+
+	// Assign the serialize function to a short function name for later usage
+
+	var er = Error
+	var fl = Float64
+	var in = Integer
+	var st = String
+	var ui = Uinteger
+
+	var a, b, c = er(fmt.Errorf("error A")), er(fmt.Errorf("error B")), er(fmt.Errorf("error C"))
+	var d, e, f = fl(1.5), fl(2.6), fl(3.7)
+	var g, h, i = in(100), in(-100), in(1000000)
+	var j, k, l = st("The"), st("Quick"), st("Brown")
+	var m, n, o = ui(400), ui(800), ui(9223372036854775808)
+
+	fmt.Printf("%v\n", a)
+	fmt.Printf("%v\n", b)
+	fmt.Printf("%v\n", c)
+	fmt.Printf("%f\n", *d)
+	fmt.Printf("%f\n", *e)
+	fmt.Printf("%f\n", *f)
+	fmt.Printf("%d\n", *g)
+	fmt.Printf("%d\n", *h)
+	fmt.Printf("%d\n", *i)
+	fmt.Printf("%s\n", j)
+	fmt.Printf("%s\n", k)
+	fmt.Printf("%s\n", l)
+	fmt.Printf("%d\n", *m)
+	fmt.Printf("%d\n", *n)
+	fmt.Printf("%d\n", *o)
+
+	// Output:
+	// error A
+	// error B
+	// error C
+	// 1.500000
+	// 2.600000
+	// 3.700000
+	// 100
+	// -100
+	// 1000000
+	// The
+	// Quick
+	// Brown
+	// 400
+	// 800
+	// 9223372036854775808
+}
+
+func ExampleSerializable_unserialize() {
+
+	var e = Error(nil)
+	var f = Float64(0)
+	var i = Integer(0)
+	var s = String("")
+	var u = Uinteger(0)
+
+	e.Unserialize("something bad happened")
+	f.Unserialize("3.14")
+	i.Unserialize("10")
+	s.Unserialize("pass")
+	u.Unserialize("20")
+
+	es, _ := e.Serialize()
+	fs, _ := f.Serialize()
+	is, _ := i.Serialize()
+	ss, _ := s.Serialize()
+	us, _ := u.Serialize()
+
+	fmt.Printf("%s\n%s\n%s\n%s\n%s", es, fs, is, ss, us)
+
+	// Output:
+	// something bad happened
+	// 3.14
+	// 10
+	// pass
+	// 20
+}
+
+func ExampleSerializable_string() {
+
+	var e = Error(nil)
+	var f = Float64(0)
+	var i = Integer(0)
+	var s = String("")
+	var u = Uinteger(0)
+
+	e.Unserialize("something bad happened")
+	f.Unserialize("3.14")
+	i.Unserialize("10")
+	s.Unserialize("pass")
+	u.Unserialize("20")
+
+	fmt.Printf("%s\n%s\n%s\n%s\n%s", e, f, i, s, u)
+
+	// Output:
+	// something bad happened
+	// 3.14
+	// 10
+	// pass
+	// 20
+}
+
+func ExampleSerializable_interface() {
+
+	var e = Error(nil)
+	var f = Float64(0)
+	var i = Integer(0)
+	var s = String("")
+	var u = Uinteger(0)
+
+	e.Unserialize("something bad happened")
+	f.Unserialize("3.14")
+	i.Unserialize("10")
+	s.Unserialize("pass")
+	u.Unserialize("20")
+
+	fmt.Printf("%v\n%f\n%d\n%q\n%d", e.Interface(), f.Interface(), i.Interface(), s.Interface(), u.Interface())
+
+	// Output:
+	// something bad happened
+	// 3.140000
+	// 10
+	// "pass"
+	// 20
+}
+
+func ExampleSerializable_params() {
+
+	var e = ErrParam
+	var f = F64Param
+	var i = IntParam
+	var s = StrParam
+	var u = UintParam
+
+	e.Unserialize("something bad happened")
+	f.Unserialize("3.14")
+	i.Unserialize("10")
+	s.Unserialize("pass")
+	u.Unserialize("20")
+
+	fmt.Printf("%q\n%q\n%q\n%q\n%q", e, f, i, s, u)
+
+	// Output:
+	// ""
+	// ""
+	// ""
+	// ""
+	// ""
+}
+
+func ExampleSerializable_binary() {
+	r := strings.NewReader("This is streamed data")
+
+	// binary doesn't serialize to a string, but it
+	// provides a io.Reader from the Interface() method
+	b := Binary(r)
+
+	io.Copy(os.Stdout, b.Interface().(io.Reader))
+	b.Interface().(io.Seeker).Seek(0, 0)
+	fmt.Println("\n----")
+	// There is also the hidden (io.Reader) interface
+
+	io.Copy(os.Stdout, b)
+
+	// Output:
+	// This is streamed data
+	// ----
+	// This is streamed data
+}
+
+type pizza struct {
+	crust    string
+	toppings []string
+}
+
+func (z *pizza) Serialize() (string, error) {
+	return fmt.Sprintf("crust:%s top:%s", z.crust, strings.Join(z.toppings, ",")), nil
+}
+func (z *pizza) Unserialize(str string) error {
+	items := strings.Split(str, " ")
+	for i, item := range items {
+		if i == 0 {
+			z.crust = strings.TrimPrefix(item, "crust:")
+			continue
+		}
+		z.toppings = strings.Split(strings.TrimPrefix(item, "top:"), ",")
+	}
+	return nil
+}
+
+func ExampleSerializable_custom() {
+
+	pepperoni := &pizza{crust: "thin", toppings: []string{"cheese", "pepperoni"}}
+	fmt.Println(pepperoni.Serialize())
+
+	cheese := &pizza{}
+	cheese.Unserialize("crust:cheese top:mozzarella,gorgonzola,goat,parmesan")
+	fmt.Println(cheese)
+
+	// Output:
+	// crust:thin top:cheese,pepperoni <nil>
+	// &{cheese [mozzarella gorgonzola goat parmesan]}
+}

--- a/server.v2_test.go
+++ b/server.v2_test.go
@@ -17,96 +17,16 @@ import (
 )
 
 func TestServerV2(t *testing.T) {
-	var opts []testingOption
-
-	type (
-		v2TestFn       func(*testing.T)
-		v2ParamsInFn   func(socketio.Server, int, map[string][][]string, *sync.WaitGroup) v2TestFn
-		v2ParamsOutFn  func(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup)
-		v2TestServerFn func(...testingOption) v2ParamsInFn
-	)
-
+	var opts = []func(*testing.T){runTest("")}
 	var EIOv = 3
 
-	runWithOptions := map[string]v2TestServerFn{
-		".Polling": func(...testingOption) v2ParamsInFn {
-			return func(v2 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) v2TestFn {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var (
-						server = httptest.NewServer(v2)
-						client = make([]*testClient, count)
-					)
-
-					// send onConnect events (auto onConnect for v2)
-					for i := 0; i < count; i++ {
-						client[i] = &testClient{polling: &v1PollingClient{
-							t:          t,
-							base:       server.URL,
-							client:     server.Client(),
-							buffer:     new(bytes.Buffer),
-							eioVersion: EIOv,
-						}}
-
-						var queryStr []string
-						if q, ok := seq["connect_query"]; ok {
-							queryStr = q[i]
-						}
-						client[i].polling.connect(queryStr)
-					}
-
-					// wait for all onConnection events to complete...
-					syncOn.Wait()
-
-					var x int
-					reqSequence := []string{"send1", "grab1", "send2", "grab2"}
-					for _, reqType := range reqSequence {
-						if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "send") {
-							var packetBuf = new(bytes.Buffer)
-
-							for i, packets := range request {
-								x++
-								if len(packets) == 0 {
-									continue
-								}
-
-								syncOn.Add(1)
-								packetBuf.Reset()
-
-								for _, packet := range packets {
-									packetBuf.WriteString(fmt.Sprintf("%d:%s", len(packet), packet))
-								}
-								client[i].polling.send(packetBuf)
-							}
-							continue
-						}
-						if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "grab") {
-							for i, want := range request {
-								x++
-								have := client[i].polling.grab()
-								assert.Equal(t, want, have, "[%s] idx: %d", reqType, i)
-							}
-							continue
-						}
-					}
-
-					// wait for all emitted events to complete...
-					syncOn.Wait()
-
-					// check that we hit every "want" that we needed to check...
-					if xq, ok := seq["connect_query"]; ok {
-						x += len(xq)
-					}
-					assert.Equal(t, count*len(seq), x)
-				}
-			}
+	runWithOptions := map[string]testParamsInFn{
+		"polling": func(v1 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) testFn {
+			return PollingTestV2(opts, EIOv, v1, count, seq, syncOn)
 		},
 	}
 
-	integration := map[string]v2ParamsOutFn{
+	integration := map[string]testParamsOutFn{
 		"sending to the client":                                                   SendingToTheClientV2,
 		"sending to all clients except sender":                                    SendingToAllClientsExceptTheSenderV2,
 		"sending to all clients in 'game' room except sender":                     SendingToAllClientsInGameRoomExceptSenderV2,
@@ -117,23 +37,98 @@ func TestServerV2(t *testing.T) {
 		"sending to individual socketid (private message)":                        SendingToIndividualSocketIDPrivateMessageV2,
 		"sending with acknowledgement":                                            SendingWithAcknowledgementV2,
 		"sending to all connected clients":                                        SendingToAllConnectedClientsV2,
+
 		// extra
 		"on event":                               OnEventV2,
 		"reject the client":                      RejectTheClientV2,
 		"sending a binary event from the client": SendingBinaryEventFromClientV2,
 	}
 
-	for name, testing := range integration {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing(t)))
+	for name, testParams := range integration {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
 	}
 
 }
 
+func PollingTestV2(opts []func(*testing.T), EIOv int, v1 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) testFn {
+	return func(t *testing.T) {
+		for _, opt := range opts {
+			opt(t)
+		}
+
+		var (
+			server = httptest.NewServer(v1)
+			client = make([]*testClient, count)
+		)
+
+		// send onConnect events (auto onConnect for v2)
+		for i := 0; i < count; i++ {
+			client[i] = &testClient{polling: &v1PollingClient{
+				t:          t,
+				base:       server.URL,
+				client:     server.Client(),
+				buffer:     new(bytes.Buffer),
+				eioVersion: EIOv,
+			}}
+
+			var queryStr []string
+			if q, ok := seq["connect_query"]; ok {
+				queryStr = q[i]
+			}
+			client[i].polling.connect(queryStr)
+		}
+
+		// wait for all onConnection events to complete...
+		syncOn.Wait()
+
+		var x int
+		reqSequence := []string{"send1", "grab1", "send2", "grab2"}
+		for _, reqType := range reqSequence {
+			if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "send") {
+				var packetBuf = new(bytes.Buffer)
+
+				for i, packets := range request {
+					x++
+					if len(packets) == 0 {
+						continue
+					}
+
+					syncOn.Add(1)
+					packetBuf.Reset()
+
+					for _, packet := range packets {
+						packetBuf.WriteString(fmt.Sprintf("%d:%s", len(packet), packet))
+					}
+					client[i].polling.send(packetBuf)
+				}
+				continue
+			}
+			if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "grab") {
+				for i, want := range request {
+					x++
+					have := client[i].polling.grab()
+					assert.Equal(t, want, have, "[%s] idx: %d", reqType, i)
+				}
+				continue
+			}
+		}
+
+		// wait for all emitted events to complete...
+		syncOn.Wait()
+
+		// check that we hit every "want" that we needed to check...
+		if xq, ok := seq["connect_query"]; ok {
+			x += len(xq)
+		}
+		assert.Equal(t, count*len(seq), x)
+	}
+}
+
 func SendingToTheClientV2(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v2   = socketio.NewServerV2()
+		v2   = socketio.NewServerV2(testingQuickPoll)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -146,7 +141,7 @@ func SendingToTheClientV2(t *testing.T) (socketio.Server, int, map[string][][]st
 		count = len(want["grab1"])
 
 		str = serialize.String
-		one = serialize.Int(1)
+		one = serialize.Integer(1)
 	)
 
 	checkCount(t, count)
@@ -155,7 +150,7 @@ func SendingToTheClientV2(t *testing.T) (socketio.Server, int, map[string][][]st
 	v2.OnConnect(func(socket *socketio.SocketV2) error {
 		defer wait.Done()
 
-		socket.Emit("hello", str("can you hear me?"), one, serialize.Int(2), str("abc"))
+		socket.Emit("hello", str("can you hear me?"), one, serialize.Integer(2), str("abc"))
 		return nil
 	})
 
@@ -164,7 +159,7 @@ func SendingToTheClientV2(t *testing.T) (socketio.Server, int, map[string][][]st
 
 func SendingToAllClientsExceptTheSenderV2(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v2   = socketio.NewServerV2()
+		v2   = socketio.NewServerV2(testingQuickPoll)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -498,7 +493,7 @@ func SendingWithAcknowledgementV2(t *testing.T) (socketio.Server, int, map[strin
 		wait.Done()
 
 		err := socket.Emit("question", question, callback.Wrap{
-			Parameters: []serialize.Serializable{serialize.Str, serialize.ISize},
+			Parameters: []serialize.Serializable{serialize.StrParam, serialize.IntParam},
 			Func: func() interface{} {
 				return func(value1 string, value2 int) error {
 					wait.Done()
@@ -591,7 +586,7 @@ func OnEventV2(t *testing.T) (socketio.Server, int, map[string][][]string, *sync
 		socket.Join("room")
 
 		socket.On("chat message", callback.Wrap{
-			Parameters: []serialize.Serializable{serialize.Str},
+			Parameters: []serialize.Serializable{serialize.StrParam},
 			Func: func() interface{} {
 
 				return func(msg string) error {
@@ -643,7 +638,7 @@ func RejectTheClientV2(t *testing.T) (socketio.Server, int, map[string][][]strin
 
 		tf := socket.Request().URL.Query().Get("access")
 		if tf == "true" {
-			socket.Emit("hello", serialize.Int(1))
+			socket.Emit("hello", serialize.Integer(1))
 			return nil
 		}
 

--- a/server.v4_test.go
+++ b/server.v4_test.go
@@ -16,104 +16,16 @@ import (
 )
 
 func TestServerV4(t *testing.T) {
-	var opts []testingOption
-
-	type (
-		v4TestFn       func(*testing.T)
-		v4ParamsInFn   func(socketio.Server, int, map[string][][]string, *sync.WaitGroup) v4TestFn
-		v4ParamsOutFn  func(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup)
-		v4TestServerFn func(...testingOption) v4ParamsInFn
-	)
-
+	var opts = []func(*testing.T){runTest("")}
 	var EIOv = 4
 
-	runWithOptions := map[string]v4TestServerFn{
-		".Polling": func(...testingOption) v4ParamsInFn {
-			return func(v4 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) v4TestFn {
-				return func(t *testing.T) {
-					for _, opt := range opts {
-						opt(t)
-					}
-
-					var (
-						server = httptest.NewServer(v4)
-						client = make([]*testClient, count)
-					)
-
-					for i := 0; i < count; i++ {
-						client[i] = &testClient{polling: &v3PollingClient{
-							t:          t,
-							base:       server.URL,
-							client:     server.Client(),
-							buffer:     new(bytes.Buffer),
-							eioVersion: EIOv,
-						}}
-
-						var queryStr, connStr []string
-
-						if q, ok := seq["connect_query"]; ok {
-							queryStr = q[i]
-						}
-						if c, ok := seq["connect"]; ok {
-							connStr = c[i]
-						}
-
-						client[i].polling.connect(queryStr, connStr)
-					}
-
-					syncOn.Wait() // waits for all of the events inside of a onConnection to complete...
-
-					var x int
-					reqSequence := []string{"send1", "grab1", "send2", "grab2"}
-					for _, reqType := range reqSequence {
-						if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "send") {
-							var packetBuf = new(bytes.Buffer)
-
-							for i, packets := range request {
-								x++
-								if len(packets) == 0 {
-									continue
-								}
-
-								syncOn.Add(1)
-								packetBuf.Reset()
-
-								for i, packet := range packets {
-									if i > 0 {
-										packetBuf.WriteByte(0x1e)
-									}
-									packetBuf.WriteString(packet)
-								}
-								client[i].polling.send(packetBuf)
-							}
-							continue
-						}
-						if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "grab") {
-							for i, want := range request {
-								x++
-								have := client[i].polling.grab()
-								assert.Equal(t, want, have, "[%s] idx: %d", reqType, i)
-							}
-							continue
-						}
-					}
-
-					syncOn.Wait()
-
-					if xq, ok := seq["connect_query"]; ok {
-						x += len(xq)
-					}
-					if xc, ok := seq["connect"]; ok {
-						x += len(xc)
-					}
-
-					assert.Equal(t, count*len(seq), x) // the wants were actually tested
-				}
-			}
+	runWithOptions := map[string]testParamsInFn{
+		".polling": func(v4 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) testFn {
+			return PollingTestV4(opts, EIOv, v4, count, seq, syncOn)
 		},
 	}
 
-	integration := map[string]v4ParamsOutFn{
+	integration := map[string]testParamsOutFn{
 		// spec - https://socket.io/docs/v3/emit-cheatsheet/
 		"sending to the client":                                                   SendingToTheClientV4,
 		"sending to all clients except sender":                                    SendingToAllClientsExceptTheSenderV4,
@@ -126,6 +38,7 @@ func TestServerV4(t *testing.T) {
 		"sending to individual socketid (private message)":                        SendingToIndividualSocketIDPrivateMessageV4,
 		"sending with acknowledgement":                                            SendingWithAcknowledgementV4,
 		"sending to all connected clients":                                        SendingToAllConnectedClientsV4,
+
 		// extra
 		"on event":                                   OnEventV4,
 		"reject the client":                          RejectTheClientV4,
@@ -133,16 +46,98 @@ func TestServerV4(t *testing.T) {
 		"sending a binary ack event from the client": SendingBinaryAckFromClientV4,
 	}
 
-	for name, testing := range integration {
-		for suffix, runWithOption := range runWithOptions {
-			t.Run(name+suffix, runWithOption(opts...)(testing(t)))
+	for name, testParams := range integration {
+		for suffix, run := range runWithOptions {
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
 		}
+	}
+}
+
+func PollingTestV4(opts []func(*testing.T), EIOv int, v4 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) testFn {
+	return func(t *testing.T) {
+		for _, opt := range opts {
+			opt(t)
+		}
+
+		var (
+			server = httptest.NewServer(v4)
+			client = make([]*testClient, count)
+		)
+
+		for i := 0; i < count; i++ {
+			client[i] = &testClient{polling: &v3PollingClient{
+				t:          t,
+				base:       server.URL,
+				client:     server.Client(),
+				buffer:     new(bytes.Buffer),
+				eioVersion: EIOv,
+			}}
+
+			var queryStr, connStr []string
+
+			if q, ok := seq["connect_query"]; ok {
+				queryStr = q[i]
+			}
+			if c, ok := seq["connect"]; ok {
+				connStr = c[i]
+			}
+
+			client[i].polling.connect(queryStr, connStr)
+		}
+
+		syncOn.Wait() // waits for all of the events inside of a onConnection to complete...
+
+		var x int
+		reqSequence := []string{"send1", "grab1", "send2", "grab2"}
+		for _, reqType := range reqSequence {
+			if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "send") {
+				var packetBuf = new(bytes.Buffer)
+
+				for i, packets := range request {
+					x++
+					if len(packets) == 0 {
+						continue
+					}
+
+					syncOn.Add(1)
+					packetBuf.Reset()
+
+					for i, packet := range packets {
+						if i > 0 {
+							packetBuf.WriteByte(0x1e)
+						}
+						packetBuf.WriteString(packet)
+					}
+					client[i].polling.send(packetBuf)
+				}
+				continue
+			}
+			if request, ok := seq[reqType]; ok && strings.HasPrefix(reqType, "grab") {
+				for i, want := range request {
+					x++
+					have := client[i].polling.grab()
+					assert.Equal(t, want, have, "[%s] idx: %d", reqType, i)
+				}
+				continue
+			}
+		}
+
+		syncOn.Wait()
+
+		if xq, ok := seq["connect_query"]; ok {
+			x += len(xq)
+		}
+		if xc, ok := seq["connect"]; ok {
+			x += len(xc)
+		}
+
+		assert.Equal(t, count*len(seq), x) // the wants were actually tested
 	}
 }
 
 func SendingToTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4()
+		v4   = socketio.NewServerV4(testingQuickPoll)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -155,7 +150,7 @@ func SendingToTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]st
 		count = len(want["grab1"])
 
 		str = serialize.String
-		one = serialize.Int(1)
+		one = serialize.Integer(1)
 	)
 
 	checkCount(t, count)
@@ -164,7 +159,7 @@ func SendingToTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]st
 	v4.OnConnect(func(socket *socketio.SocketV4) error {
 		defer wait.Done()
 
-		socket.Emit("hello", str("can you hear me?"), one, serialize.Int(2), str("abc"))
+		socket.Emit("hello", str("can you hear me?"), one, serialize.Integer(2), str("abc"))
 		return nil
 	})
 
@@ -173,7 +168,7 @@ func SendingToTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]st
 
 func SendingToAllClientsExceptTheSenderV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4()
+		v4   = socketio.NewServerV4(testingQuickPoll)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -554,7 +549,7 @@ func SendingWithAcknowledgementV4(t *testing.T) (socketio.Server, int, map[strin
 		wait.Done()
 
 		err := socket.Emit("question", question, callback.Wrap{
-			Parameters: []serialize.Serializable{serialize.Str, serialize.ISize},
+			Parameters: []serialize.Serializable{serialize.StrParam, serialize.IntParam},
 			Func: func() interface{} {
 				return func(value1 string, value2 int) error {
 					wait.Done()
@@ -646,7 +641,7 @@ func OnEventV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync
 
 		socket.Join("room")
 		socket.On("chat message", callback.Wrap{
-			Parameters: []serialize.Serializable{serialize.Str},
+			Parameters: []serialize.Serializable{serialize.StrParam},
 			Func: func() interface{} {
 
 				return func(msg string) error {
@@ -699,7 +694,7 @@ func RejectTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]strin
 
 		tf := socket.Request().URL.Query().Get("access")
 		if tf == "true" {
-			socket.Emit("hello", serialize.Int(1))
+			socket.Emit("hello", serialize.Integer(1))
 			return nil
 		}
 
@@ -773,7 +768,7 @@ func SendingBinaryAckFromClientV4(t *testing.T) (socketio.Server, int, map[strin
 		defer wait.Done()
 
 		err := socket.Emit("question", question, callback.Wrap{
-			Parameters: []serialize.Serializable{serialize.Bin},
+			Parameters: []serialize.Serializable{serialize.BinParam},
 			Func: func() interface{} {
 				return func(value1 io.Reader) error {
 					wait.Done()


### PR DESCRIPTION
All tests are updated to look similar and follow the same `t.Run`
sub-test format. Also this commit expands the test coverage for
Callable and Serializable through examples.