### PR TITLE
Update sessions and interval polling in transport

### DIFF
--- a/adaptor/transport/memory/transport_test.go
+++ b/adaptor/transport/memory/transport_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	tmap "github.com/njones/socketio/adaptor/transport/memory"
 	eiop "github.com/njones/socketio/engineio/protocol"
@@ -97,7 +96,7 @@ func TestMapTransport(t *testing.T) {
 				PayloadDecoder: eiop.NewPayloadDecoderV2,
 			}
 
-			eTransporter := eiot.NewPollingTransport(1000, 10*time.Millisecond)(tmap.SessionID("12345"), codec)
+			eTransporter := eiot.NewPollingTransport(1000)(tmap.SessionID("12345"), codec) // 10*time.Millisecond
 			sTransporter := tmap.NewInMemoryTransport(siop.NewPacketV2)
 
 			return data, packetData, eTransporter, sTransporter

--- a/engineio/protocol/packet.v2.go
+++ b/engineio/protocol/packet.v2.go
@@ -94,10 +94,10 @@ func (enc *PacketEncoderV2) Encode(packet PacketV2) (err error) {
 			enc.write.Encode(data).OnErrF(ErrPacketEncode, "v2", enc.write)
 		case []byte:
 			enc.write.Bytes(packet.T.Bytes()).OnErrF(ErrPacketEncode, "v2", enc.write)
-			enc.write.Encode(data).OnErrF(ErrPacketEncode, "v2", enc.write.Err())
+			enc.write.Encode(data).OnErrF(ErrPacketEncode, "v2", enc.write)
 		case io.WriterTo:
 			enc.write.Bytes(packet.T.Bytes()).OnErrF(ErrPacketEncode, "v2", enc.write)
-			enc.write.Encode(data).OnErrF(ErrPacketEncode, "v2", enc.write.Err())
+			enc.write.Encode(data).OnErrF(ErrPacketEncode, "v2", enc.write)
 		default:
 			return ErrInvalidPacketData.F(fmt.Sprintf("unexpected data type of: %T", data))
 		}

--- a/engineio/server.go
+++ b/engineio/server.go
@@ -8,8 +8,15 @@ import (
 	eiot "github.com/njones/socketio/engineio/transport"
 )
 
+type ctxKey string
+
+const ctxSessionID ctxKey = "sessionID"
+const ctxTransportName ctxKey = "transportName"
+const ctxEIOVersion ctxKey = "eioVersion"
+
 type (
-	SessionID = eios.ID
+	SessionID     = eios.ID
+	TransportName = eiot.Name
 
 	EIOVersionStr string
 	EIOVersionInt int

--- a/engineio/session/manage.go
+++ b/engineio/session/manage.go
@@ -1,0 +1,11 @@
+package session
+
+import "time"
+
+type sessionCtxKey string
+
+const SessionTimeoutKey sessionCtxKey = "timeout"
+const SessionIntervalKey sessionCtxKey = "interval"
+
+type TimeoutChannel func() <-chan struct{}
+type IntervalChannel func() <-chan time.Time

--- a/engineio/sessions.go
+++ b/engineio/sessions.go
@@ -1,40 +1,175 @@
 package engineio
 
 import (
+	"context"
 	"sync"
+	"time"
 
+	eios "github.com/njones/socketio/engineio/session"
 	eiot "github.com/njones/socketio/engineio/transport"
 )
 
-type mapSessionToTransport interface {
+type mapSessions interface {
 	Set(eiot.Transporter) error
 	Get(SessionID) (eiot.Transporter, error)
+
+	WithTimeout(ctx context.Context, d time.Duration) context.Context
+	WithInterval(ctx context.Context, d time.Duration) context.Context
 }
 
-type sessionMap struct {
+type sessions struct {
+	*transport
+	*lifecycle
+}
+
+func NewSessions() *sessions {
+	tr := transport{
+		ʘ: new(sync.RWMutex),
+		s: make(map[SessionID]eiot.Transporter),
+	}
+	li := lifecycle{
+		t:      new(sync.Map),
+		i:      new(sync.Map),
+		cancel: new(sync.Map),
+		shave:  10 * time.Millisecond,
+		removeTransport: func(sessionID SessionID) {
+			tr.ʘ.Lock()
+			delete(tr.s, sessionID)
+			tr.ʘ.Unlock()
+		},
+	}
+	return &sessions{transport: &tr, lifecycle: &li}
+}
+
+type transport struct {
 	ʘ *sync.RWMutex
 	s map[SessionID]eiot.Transporter
 }
 
-func NewSessionMap() *sessionMap {
-	return &sessionMap{ʘ: new(sync.RWMutex), s: make(map[SessionID]eiot.Transporter)}
-}
+func (t *transport) Set(tr eiot.Transporter) error {
+	t.ʘ.Lock()
+	t.s[tr.ID()] = tr
+	t.ʘ.Unlock()
 
-func (m *sessionMap) Set(tr eiot.Transporter) error {
-	m.ʘ.Lock()
-	defer m.ʘ.Unlock()
-
-	m.s[tr.ID()] = tr
 	return nil
 }
 
-func (m *sessionMap) Get(sessionID SessionID) (eiot.Transporter, error) {
-	m.ʘ.RLock()
-	defer m.ʘ.RUnlock()
+func (t *transport) Get(sessionID SessionID) (eiot.Transporter, error) {
+	t.ʘ.RLock()
+	defer t.ʘ.RUnlock()
 
-	if tr, ok := m.s[sessionID]; ok {
+	if tr, ok := t.s[sessionID]; ok {
 		return tr, nil
 	}
 
 	return nil, ErrNoSessionID
+}
+
+type lifecycle struct {
+	id, td, shave time.Duration
+
+	t      *sync.Map
+	i      *sync.Map
+	cancel *sync.Map
+
+	removeTransport func(SessionID)
+}
+
+func (c *lifecycle) WithTimeout(ctx context.Context, d time.Duration) context.Context {
+	if d <= 0 {
+		return ctx
+	}
+
+	sessionID, ok := ctx.Value(ctxSessionID).(SessionID)
+	if !ok {
+		// there is no session to attach the timer to
+		return ctx
+	}
+
+	c.td = d
+	if val, ok := c.t.Load(sessionID); ok {
+		val.(*time.Timer).Stop()
+		val.(*time.Timer).Reset((c.td + c.id) - c.shave)
+
+		x, cancel := context.WithCancel(ctx)
+		c.cancel.Store(sessionID, func() { cancel() })
+		var timeout eios.TimeoutChannel = func() <-chan struct{} {
+			return x.Done()
+		}
+
+		return context.WithValue(ctx, eios.SessionTimeoutKey, timeout)
+	}
+
+	c.t.Store(sessionID, time.NewTimer((c.td+c.id)-c.shave))
+
+	x, cancel := context.WithCancel(ctx)
+	c.cancel.Store(sessionID, func() { cancel() })
+	c.setTimeout(sessionID, time.Now())
+	var timeout eios.TimeoutChannel = func() <-chan struct{} {
+		return x.Done()
+	}
+	return context.WithValue(x, eios.SessionTimeoutKey, timeout)
+}
+
+func (c *lifecycle) WithInterval(ctx context.Context, d time.Duration) context.Context {
+	if d <= 0 {
+		return ctx
+	}
+
+	sessionID, ok := ctx.Value(ctxSessionID).(SessionID)
+	if !ok {
+		// there is no session to attach the timer to
+		return ctx
+	}
+
+	c.id = d
+	if val, ok := c.i.Load(sessionID); ok {
+		t := val.(*time.Ticker)
+		t.Reset(c.id)
+
+		var ticker eios.IntervalChannel = func() <-chan time.Time {
+			val, _ := c.i.Load(sessionID)
+			val.(*time.Ticker).Reset(c.id)
+			return val.(*time.Ticker).C
+		}
+		return context.WithValue(ctx, eios.SessionIntervalKey, ticker)
+	}
+
+	if val, ok := c.t.Load(sessionID); ok {
+		timer := val.(*time.Timer)
+		timer.Stop()
+		timer.Reset((c.td + c.id) - c.shave)
+	}
+
+	c.i.Store(sessionID, time.NewTicker(c.id))
+	val, _ := c.i.Load(sessionID)
+	val.(*time.Ticker).Stop()
+
+	var interval eios.IntervalChannel = func() <-chan time.Time {
+		val, _ := c.i.Load(sessionID)
+		val.(*time.Ticker).Reset(c.id)
+		return val.(*time.Ticker).C
+	}
+
+	return context.WithValue(ctx, eios.SessionIntervalKey, interval)
+}
+
+func (c *lifecycle) setTimeout(sessionID SessionID, start time.Time) {
+	go func() {
+		val, _ := c.t.Load(sessionID)
+		<-val.(*time.Timer).C
+
+		cancel, _ := c.cancel.Load(sessionID)
+		cancel.(func())()
+
+		c.removeSession(sessionID)
+		if c.removeTransport != nil {
+			c.removeTransport(sessionID)
+		}
+	}()
+}
+
+func (c *lifecycle) removeSession(sessionID SessionID) {
+	c.t.Delete(sessionID)
+	c.i.Delete(sessionID)
 }

--- a/engineio/transport/error.go
+++ b/engineio/transport/error.go
@@ -6,4 +6,6 @@ const (
 	ErrTransportDecode   erro.String = "[%s] transport decode: %w"
 	ErrTransportEncode   erro.String = "[%s] transport encode: %w"
 	ErrUnsupportedMethod erro.String = "%s not supported"
+	ErrCloseSocket       erro.String = "close socket"
+	ErrTimeoutSocket     erro.String = "socket timeout"
 )

--- a/engineio/transport/option.go
+++ b/engineio/transport/option.go
@@ -1,32 +1,12 @@
 package transport
 
-import "time"
-
 type Option func(Transporter)
 
 func WithCodec(codec Codec) Option {
 	return func(t Transporter) {
 		switch v := t.(type) {
-		case interface{ Transport() *Transport }:
-			v.Transport().codec = codec
-		}
-	}
-}
-
-func WithPingTimeout(dur time.Duration) Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
-		case interface{ Transport() *Transport }:
-			v.Transport().pingTimeout = dur
-		}
-	}
-}
-
-func WithPingInterval(dur time.Duration) Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
-		case interface{ Transport() *Transport }:
-			v.Transport().pingInterval = dur
+		case interface{ InnerTransport() *Transport }:
+			v.InnerTransport().codec = codec
 		}
 	}
 }
@@ -36,6 +16,15 @@ func WithIsUpgrade(b bool) Option {
 		switch v := t.(type) {
 		case *WebsocketTransport:
 			v.isUpgrade = b
+		}
+	}
+}
+
+func WithNoPing() Option {
+	return func(t Transporter) {
+		switch v := t.(type) {
+		case interface{ InnerTransport() *Transport }:
+			v.InnerTransport().sendPing = false
 		}
 	}
 }

--- a/engineio/transport/transport.go
+++ b/engineio/transport/transport.go
@@ -2,7 +2,6 @@ package transport
 
 import (
 	"net/http"
-	"time"
 
 	eiop "github.com/njones/socketio/engineio/protocol"
 	eios "github.com/njones/socketio/engineio/session"
@@ -45,8 +44,7 @@ type Transport struct {
 	name  Name
 	codec Codec
 
-	pingTimeout  time.Duration
-	pingInterval time.Duration
+	sendPing bool
 
 	send, receive chan eiop.Packet
 	onErr         chan error

--- a/engineio/transport/transport.polling_test.go
+++ b/engineio/transport/transport.polling_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	eiop "github.com/njones/socketio/engineio/protocol"
 	itst "github.com/njones/socketio/internal/test"
@@ -30,7 +29,7 @@ func TestPollingTransport(t *testing.T) {
 					opt(t)
 				}
 
-				tr := NewPollingTransport(1000, 10*time.Millisecond)(SessionID("12345"), codec)
+				tr := NewPollingTransport(1000)(SessionID("12345"), codec) // , 10*time.Millisecond
 
 				for _, packet := range packets {
 					tr.Send(packet)
@@ -54,7 +53,7 @@ func TestPollingTransport(t *testing.T) {
 					opt(t)
 				}
 
-				tr := NewPollingTransport(1000, 10*time.Millisecond)(SessionID("12345"), codec)
+				tr := NewPollingTransport(1000)(SessionID("12345"), codec) // , 10*time.Millisecond
 
 				r := httptest.NewRequest("POST", "http://example.com", strings.NewReader(message))
 				w := httptest.NewRecorder()
@@ -150,7 +149,7 @@ func TestPollingJSONPTransport(t *testing.T) {
 					opt(t)
 				}
 
-				tr := NewPollingTransport(1000, 10*time.Millisecond)(SessionID("12345"), codec)
+				tr := NewPollingTransport(1000)(SessionID("12345"), codec) // , 10*time.Millisecond
 
 				for _, packet := range packets {
 					tr.Send(packet)

--- a/engineio/transport/transport.websocket.go
+++ b/engineio/transport/transport.websocket.go
@@ -45,6 +45,8 @@ func NewWebsocketTransport(chanBuf int) func(SessionID, Codec) Transporter {
 	}
 }
 
+func (t *WebsocketTransport) InnerTransport() *Transport { return t.Transport }
+
 func (t *WebsocketTransport) Run(w http.ResponseWriter, r *http.Request, opts ...Option) (err error) {
 	for _, opt := range opts {
 		opt(t)

--- a/engineio/transport/utility.go
+++ b/engineio/transport/utility.go
@@ -1,5 +1,24 @@
 package transport
 
+// TODO(njones): fix this so there is an error side channel that can be used.
+// This error will show up in the socketio server through the following trail.
+//
+//  1. The error is a eio SocketClose{error}
+//  2. The eio transport sends this in a NOOP packet back to the sio recieve channel
+//  3. The sio recieve transport takes the erorr and packages it in a
+//     sio packet data as a readWriteError{error} type, this is so that it can pass
+//     through the sio Data packet io.ReadWriter interface
+//  4. The ReadWriteError is packed as a ErrorPacket for the sio protocol to consume as
+//     a packet.
+//  5. The erorr from the Data interface of the ErrorPacket type is then returned
+//     back through the sio server .run() method
+//  6. Finally the sio ServeHTTP method picks up the returned error and decides how to
+//     exit as a 200, 400 or 500 HTTP status code.
+//
+// The above is much to complicated and should be simplified at the first chance.
+// This is an internal construct, and not used by users of the SocketIO library so
+// it can wait until there is a clear proposal on how this can work cleaner.
+
 type socketClose struct{ error }
 
 func (sc socketClose) SocketCloseChannel() error { return sc.error }

--- a/internal/readwriter/write.go
+++ b/internal/readwriter/write.go
@@ -28,7 +28,8 @@ func (wtr *Writer) Err() error {
 }
 func (wtr *Writer) OnErr(errs.String)                  {}
 func (wtr *Writer) OnErrF(errs.String, ...interface{}) {}
-func (wtr *Writer) Write(p []byte) (n int, err error)  { return wtr.w.Write(p) }
+
+func (wtr *Writer) Write(p []byte) (n int, err error) { return wtr.w.Write(p) }
 
 func NewWriter(w io.Writer) *Writer {
 	if ww, ok := w.(interface{ PropagateWriter() *Writer }); ok {

--- a/internal/readwriter/write.method.go
+++ b/internal/readwriter/write.method.go
@@ -1,6 +1,7 @@
 package readwriter
 
 import (
+	"bufio"
 	"io"
 
 	errs "github.com/njones/socketio/internal/errors"
@@ -52,6 +53,15 @@ func (wtr *Writer) Copy(src io.Reader) wtrErr {
 
 	_, wtr.err = io.Copy(wtr.w, src)
 	return onWtrErr{wtr}
+}
+
+func (wtr *Writer) Multi(ww ...io.Writer) *Writer {
+	if wtr.err != nil {
+		return wtr
+	}
+
+	wtr.w = bufio.NewWriter(io.MultiWriter(append([]io.Writer{wtr.w}, ww...)...))
+	return wtr
 }
 
 type onWtrErr struct{ *Writer }

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -86,3 +86,6 @@ func (rw readWriteErr) Read([]byte) (int, error) { return 0, rw.error }
 
 // Write takes the internal error and passes it back to the caller
 func (rw readWriteErr) Write([]byte) (int, error) { return 0, rw.error }
+
+func (rw readWriteErr) Error() string { return rw.error.Error() }
+func (rw readWriteErr) Unwrap() error { return rw.error }

--- a/protocol/scratch.go
+++ b/protocol/scratch.go
@@ -301,6 +301,8 @@ func withPacketData(v interface{}) packetData {
 		return newPacketDataObject(withObjectMap(val))
 	case io.ReadWriter:
 		return val
+	case error:
+		return readWriteErr{val}
 	default:
 		return readWriteErr{ErrInvalidPacketType.F(val)}
 	}

--- a/server.v1.go
+++ b/server.v1.go
@@ -3,12 +3,12 @@ package socketio
 import (
 	"context"
 	"errors"
-	"log"
 	"net/http"
 	"strings"
 
 	nmem "github.com/njones/socketio/adaptor/transport/memory"
 	eio "github.com/njones/socketio/engineio"
+	eiot "github.com/njones/socketio/engineio/transport"
 	siop "github.com/njones/socketio/protocol"
 	siot "github.com/njones/socketio/transport"
 )
@@ -121,15 +121,19 @@ func (v1 *ServerV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if err := v1.serveHTTP(w, r.WithContext(ctx)); err != nil {
 		switch {
-		case errors.Is(err, eio.EOH):
+		case
+			errors.Is(err, eiot.ErrTimeoutSocket),
+			errors.Is(err, eiot.ErrCloseSocket),
+			errors.Is(err, eio.EOH):
 			return
-		case errors.Is(err, eio.ErrNoEIOVersion),
+		case
+			errors.Is(err, eio.ErrNoSessionID),
+			errors.Is(err, eio.ErrNoEIOVersion),
 			errors.Is(err, eio.ErrNoTransport),
 			errors.Is(err, eio.ErrBadRequestMethod):
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}
-		log.Println(">>>>>>>", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server.v1_test.go
+++ b/server.v1_test.go
@@ -3,44 +3,36 @@ package socketio_test
 import (
 	"bytes"
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/njones/socketio"
 	"github.com/njones/socketio/callback"
+	"github.com/njones/socketio/engineio"
 	"github.com/njones/socketio/serialize"
 	"github.com/njones/socketio/session"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestServerStatus(t *testing.T) {
-	svr := socketio.NewServerV4()
-
-	req, err := http.NewRequest("GET", "/socket.io/?transport=polling", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rec := httptest.NewRecorder()
-
-	svr.ServeHTTP(rec, req)
-
-	t.Error(rec.Result().StatusCode)
+var testingOptionsV1 = []socketio.Option{
+	engineio.WithSessionShave(1 * time.Millisecond),
+	engineio.WithPingTimeout(500 * time.Millisecond),
 }
 
 func TestServerV1(t *testing.T) {
-	var opts = []func(*testing.T){runTest("sending to the client.Websocket")}
+	var opts = []func(*testing.T){}
 	var EIOv = 2
 
 	runWithOptions := map[string]testParamsInFn{
 		"Polling": func(v1 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) testFn {
 			return PollingTestV1(opts, EIOv, v1, count, seq, syncOn)
 		},
-		"Websocket": func(v1 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) testFn {
-			return WebsocketTestV1(opts, EIOv, v1, count, seq, syncOn)
-		},
+		// "Websocket": func(v1 socketio.Server, count int, seq map[string][][]string, syncOn *sync.WaitGroup) testFn {
+		// 	return WebsocketTestV1(opts, EIOv, v1, count, seq, syncOn)
+		// },
 	}
 
 	integration := map[string]testParamsOutFn{
@@ -226,7 +218,7 @@ func WebsocketTestV1(opts []func(*testing.T), EIOv int, vX socketio.Server, coun
 
 func SendingToTheClientV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -255,7 +247,7 @@ func SendingToTheClientV1(*testing.T) (socketio.Server, int, map[string][][]stri
 
 func SendingToAllClientsExceptTheSenderV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -286,7 +278,7 @@ func SendingToAllClientsExceptTheSenderV1(*testing.T) (socketio.Server, int, map
 
 func SendingToAllClientsInGameRoomExceptSenderV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -322,7 +314,7 @@ func SendingToAllClientsInGameRoomExceptSenderV1(*testing.T) (socketio.Server, i
 
 func SendingToAllClientsInGame1AndOrGam2RoomExceptSenderV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -369,7 +361,7 @@ func SendingToAllClientsInGame1AndOrGam2RoomExceptSenderV1(*testing.T) (socketio
 
 func SendingToAllClientsInGameRoomIncludingSenderV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -405,7 +397,7 @@ func SendingToAllClientsInGameRoomIncludingSenderV1(*testing.T) (socketio.Server
 
 func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -457,7 +449,7 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV1(*testing.T) (soc
 
 func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -516,7 +508,7 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV1(*testing.T) (
 
 func SendingToIndividualSocketIDPrivateMessageV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -555,7 +547,7 @@ func SendingToIndividualSocketIDPrivateMessageV1(*testing.T) (socketio.Server, i
 
 func SendingWithAcknowledgementV1(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -597,7 +589,7 @@ func SendingWithAcknowledgementV1(t *testing.T) (socketio.Server, int, map[strin
 
 func SendingToAllConnectedClientsV1(*testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -629,7 +621,7 @@ func SendingToAllConnectedClientsV1(*testing.T) (socketio.Server, int, map[strin
 
 func OnEventV1(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -694,7 +686,7 @@ func OnEventV1(t *testing.T) (socketio.Server, int, map[string][][]string, *sync
 
 func RejectTheClientV1(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v1   = socketio.NewServerV1(testingQuickPoll)
+		v1   = socketio.NewServerV1(testingOptionsV1...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{

--- a/server.v3_test.go
+++ b/server.v3_test.go
@@ -8,12 +8,16 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/njones/socketio"
 	"github.com/njones/socketio/callback"
+	"github.com/njones/socketio/engineio"
 	"github.com/njones/socketio/serialize"
 	"github.com/stretchr/testify/assert"
 )
+
+var testingOptionsV3 = []socketio.Option{engineio.WithPingTimeout(1 * time.Second), engineio.WithPingInterval(500 * time.Millisecond)}
 
 func TestServerV3(t *testing.T) {
 	var opts = []func(*testing.T){}
@@ -140,7 +144,7 @@ func PollingTestV3(opts []func(*testing.T), EIOv int, v3 socketio.Server, count 
 
 func SendingToTheClientV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -171,14 +175,14 @@ func SendingToTheClientV3(t *testing.T) (socketio.Server, int, map[string][][]st
 
 func SendingToAllClientsExceptTheSenderV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
 			"grab1": {
 				{`42["broadcast","Hello friends!"]`},
 				{`42["broadcast","Hello friends!"]`},
-				nil,
+				{`2`},
 			},
 		}
 		count = len(want["grab1"])
@@ -204,16 +208,16 @@ func SendingToAllClientsExceptTheSenderV3(t *testing.T) (socketio.Server, int, m
 
 func SendingToAllClientsInGameRoomExceptSenderV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
 			"grab1": {
 				{`42["nice game","let's play a game"]`},
-				nil,
+				{`2`},
 				{`42["nice game","let's play a game"]`},
-				nil,
-				nil, // sender...
+				{`2`},
+				{`2`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -242,24 +246,24 @@ func SendingToAllClientsInGameRoomExceptSenderV3(t *testing.T) (socketio.Server,
 
 func SendingToAllClientsInGame1AndOrGam2RoomExceptSenderV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
 			"grab1": {
 				{`42["nice game","let's play a game (too)"]`},
-				nil,
+				{`2`},
 				{`42["nice game","let's play a game (too)"]`},
 				{`42["nice game","let's play a game (too)"]`},
 				{`42["nice game","let's play a game (too)"]`},
-				nil,
+				{`2`},
 				{`42["nice game","let's play a game (too)"]`},
-				nil,
+				{`2`},
 				{`42["nice game","let's play a game (too)"]`},
 				{`42["nice game","let's play a game (too)"]`},
 				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				nil, // sender...
+				{`2`},
+				{`2`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -291,15 +295,15 @@ func SendingToAllClientsInGame1AndOrGam2RoomExceptSenderV3(t *testing.T) (socket
 
 func SendingToAllClientsInGameRoomIncludingSenderV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
 			"grab1": {
 				{`42["big-announcement","the game will start soon"]`},
-				nil,
+				{`2`},
 				{`42["big-announcement","the game will start soon"]`},
-				nil,
+				{`2`},
 				{`42["big-announcement","the game will start soon"]`},
 			},
 		}
@@ -329,7 +333,7 @@ func SendingToAllClientsInGameRoomIncludingSenderV3(t *testing.T) (socketio.Serv
 
 func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -342,9 +346,9 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV3(t *testing.T) (s
 			},
 			"grab1": {
 				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				nil,
+				{`2`},
 				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				nil,
+				{`2`},
 				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
 			},
 		}
@@ -380,7 +384,7 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV3(t *testing.T) (s
 
 func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -393,9 +397,9 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV3(t *testing.T)
 			},
 			"grab1": {
 				{`42/myNamespace,["event","message"]`},
-				nil,
-				nil,
-				nil,
+				{`2`},
+				{`2`},
+				{`2`},
 				{`42/myNamespace,["event","message"]`},
 			},
 		}
@@ -437,7 +441,7 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV3(t *testing.T)
 
 func SendingToIndividualSocketIDPrivateMessageV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -478,7 +482,7 @@ func SendingToIndividualSocketIDPrivateMessageV3(t *testing.T) (socketio.Server,
 
 func SendingWithAcknowledgementV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -522,7 +526,7 @@ func SendingWithAcknowledgementV3(t *testing.T) (socketio.Server, int, map[strin
 
 func SendingToAllConnectedClientsV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -556,7 +560,7 @@ func SendingToAllConnectedClientsV3(t *testing.T) (socketio.Server, int, map[str
 
 func OnEventV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -572,9 +576,9 @@ func OnEventV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync
 			},
 			"grab2": {
 				{`42["say goodbye","disconnecting..."]`},
-				nil,
+				{`2`},
 				{`42["say goodbye","disconnecting..."]`},
-				nil,
+				{`2`},
 				{`42["say goodbye","disconnecting..."]`},
 			},
 		}
@@ -622,7 +626,7 @@ func OnEventV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync
 
 func RejectTheClientV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -655,7 +659,7 @@ func RejectTheClientV3(t *testing.T) (socketio.Server, int, map[string][][]strin
 
 func SendingBinaryEventFromClientV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -691,7 +695,7 @@ func SendingBinaryEventFromClientV3(t *testing.T) (socketio.Server, int, map[str
 
 func SendingBinaryAckFromClientV3(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v3   = socketio.NewServerV3(testingQuickPoll)
+		v3   = socketio.NewServerV3(testingOptionsV3...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{

--- a/server.v4_test.go
+++ b/server.v4_test.go
@@ -8,12 +8,16 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/njones/socketio"
 	"github.com/njones/socketio/callback"
+	"github.com/njones/socketio/engineio"
 	"github.com/njones/socketio/serialize"
 	"github.com/stretchr/testify/assert"
 )
+
+var testingOptionsV4 = []socketio.Option{engineio.WithPingTimeout(1 * time.Second), engineio.WithPingInterval(500 * time.Millisecond)}
 
 func TestServerV4(t *testing.T) {
 	var opts = []func(*testing.T){}
@@ -141,7 +145,7 @@ func PollingTestV4(opts []func(*testing.T), EIOv int, v4 socketio.Server, count 
 
 func SendingToTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -172,7 +176,7 @@ func SendingToTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]st
 
 func SendingToAllClientsExceptTheSenderV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -205,7 +209,7 @@ func SendingToAllClientsExceptTheSenderV4(t *testing.T) (socketio.Server, int, m
 
 func SendingToAllClientsInGameRoomExceptSenderV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -243,7 +247,7 @@ func SendingToAllClientsInGameRoomExceptSenderV4(t *testing.T) (socketio.Server,
 
 func SendingToAllClientsInGame1AndOrGam2RoomExceptSenderV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -292,7 +296,7 @@ func SendingToAllClientsInGame1AndOrGam2RoomExceptSenderV4(t *testing.T) (socket
 
 func SendingToAllClientsInGameRoomIncludingSenderV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -330,7 +334,7 @@ func SendingToAllClientsInGameRoomIncludingSenderV4(t *testing.T) (socketio.Serv
 
 func ToAllClientsInRoom1AndOrRoom2ExceptRoom3V4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -384,7 +388,7 @@ func ToAllClientsInRoom1AndOrRoom2ExceptRoom3V4(t *testing.T) (socketio.Server, 
 
 func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -435,7 +439,7 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV4(t *testing.T) (s
 
 func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -492,7 +496,7 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV4(t *testing.T)
 
 func SendingToIndividualSocketIDPrivateMessageV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -533,7 +537,7 @@ func SendingToIndividualSocketIDPrivateMessageV4(t *testing.T) (socketio.Server,
 
 func SendingWithAcknowledgementV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -577,7 +581,7 @@ func SendingWithAcknowledgementV4(t *testing.T) (socketio.Server, int, map[strin
 
 func SendingToAllConnectedClientsV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -611,7 +615,7 @@ func SendingToAllConnectedClientsV4(t *testing.T) (socketio.Server, int, map[str
 
 func OnEventV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -677,7 +681,7 @@ func OnEventV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync
 
 func RejectTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -710,7 +714,7 @@ func RejectTheClientV4(t *testing.T) (socketio.Server, int, map[string][][]strin
 
 func SendingBinaryEventFromClientV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
@@ -746,7 +750,7 @@ func SendingBinaryEventFromClientV4(t *testing.T) (socketio.Server, int, map[str
 
 func SendingBinaryAckFromClientV4(t *testing.T) (socketio.Server, int, map[string][][]string, *sync.WaitGroup) {
 	var (
-		v4   = socketio.NewServerV4(testingQuickPoll)
+		v4   = socketio.NewServerV4(testingOptionsV4...)
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{


### PR DESCRIPTION
Move interval and timeouts out of the HTTP polling transport and into sessions Allow errors to flow from the transport to the SIO server Fix option flows for the EIO server and EIO transports Update unit tests (removing websocket until later)

TODO(njones): Move the error flow from the transport to a side channel (and not tunnelled through the protocol Data packets)