### PR TITLE
Update the EIO polling and websocket Close type

### DIFF
--- a/engineio/server.v4.go
+++ b/engineio/server.v4.go
@@ -103,6 +103,7 @@ func (v4 *serverV4) serveTransport(w http.ResponseWriter, r *http.Request) (tran
 		opts = []eiot.Option{eiot.WithIsUpgrade(isUpgrade)}
 	}
 
+	ctx = v4.sessions.WithCancel(ctx)
 	ctx = v4.sessions.WithInterval(ctx, v4.pingInterval)
 	ctx = v4.sessions.WithTimeout(ctx, v4.pingTimeout)
 

--- a/engineio/session/manage.go
+++ b/engineio/session/manage.go
@@ -5,11 +5,15 @@ import "time"
 type sessionCtxKey string
 
 const (
-	SessionExtendTimeoutKey sessionCtxKey = "extendTimeout"
-	SessionTimeoutKey       sessionCtxKey = "timeout"
-	SessionIntervalKey      sessionCtxKey = "interval"
+	SessionTimeoutKey        sessionCtxKey = "timeout"
+	SessionIntervalKey       sessionCtxKey = "interval"
+	SessionExtendTimeoutKey  sessionCtxKey = "timeout-extend"
+	SessionCancelChannelKey  sessionCtxKey = "cancel-channel"
+	SessionCancelFunctionKey sessionCtxKey = "cancel-function"
 )
 
-type ExtendTimeoutFunc func()
-type TimeoutChannel func() <-chan struct{}
-type IntervalChannel func() <-chan time.Time
+type (
+	TimeoutChannel    func() <-chan struct{}
+	IntervalChannel   func() <-chan time.Time
+	ExtendTimeoutFunc func()
+)

--- a/engineio/session/session.go
+++ b/engineio/session/session.go
@@ -7,7 +7,8 @@ import (
 
 type ID string
 
-func (id ID) String() string { return string(id) }
+func (id ID) String() string            { return string(id) }
+func (id ID) PrefixID(prefix string) ID { return ID(prefix + string(id)) }
 
 var GenerateID = func() ID {
 	b := make([]byte, 16)

--- a/engineio/transport/transport.go
+++ b/engineio/transport/transport.go
@@ -47,7 +47,6 @@ type Transport struct {
 	sendPing bool
 
 	send, receive chan eiop.Packet
-	onErr         chan error
 
 	shutdown func()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.17
 
 require (
 	github.com/gobwas/ws v1.1.0
+	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.7.1
+	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/net v0.0.0-20190603091049-60506f45cf65
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/text v0.3.7
 	nhooyr.io/websocket v1.8.7
@@ -17,8 +20,6 @@ require (
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/klauspost/compress v1.10.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
-	golang.org/x/net v0.0.0-20190603091049-60506f45cf65 // indirect
 	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgj
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=


### PR DESCRIPTION
Sending a close type to an EIO polling or websocket transport will now close all connections in roughly the correct order.