### PR TITLE
Add handshake data to *SocketV4

### DIFF
--- a/serialize/serialize.go
+++ b/serialize/serialize.go
@@ -1,6 +1,7 @@
 package serialize
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"strconv"
@@ -53,6 +54,7 @@ var (
 	ErrParam  = _errorWrap{Error(nil)}
 	F64Param  = _float64Param{Float64(0)}
 	IntParam  = _intParam{Integer(0)}
+	MapParam  = _mapParam{Map(nil)}
 	StrParam  = _stringParam{String("")}
 	UintParam = _uintParam{Uinteger(0)}
 )
@@ -120,6 +122,20 @@ func (x *_int) Interface() (v interface{})   { return int(*x) }
 func (x _intParam) Unserialize(string) error { return nil }
 func (x _intParam) String() string           { return "" }
 func (x _int) Param() Serializable           { v := _int(0); return &v }
+
+type (
+	_map      map[string]interface{}
+	_mapParam struct{ SerializableParam }
+)
+
+func Map(m map[string]interface{}) _map           { return _map(m) }
+func (x _map) String() (str string)               { str, _ = x.Serialize(); return }
+func (x _map) Serialize() (str string, err error) { b, err := json.Marshal(x); return string(b), err }
+func (x _map) Unserialize(str string) (err error) { return json.Unmarshal([]byte(str), &x) }
+func (x _map) Interface() (v interface{})         { return (map[string]interface{})(x) }
+func (x _mapParam) Unserialize(string) error      { return nil }
+func (x _mapParam) String() string                { return "" }
+func (x _map) Param() Serializable                { return _map{} }
 
 type (
 	_string      string

--- a/server.v4.go
+++ b/server.v4.go
@@ -10,6 +10,16 @@ import (
 
 // https://socket.io/docs/v4/migrating-from-3-x-to-4-0/
 
+type handshakeV4 struct {
+	Auth func() map[string]interface{}
+}
+
+func (v4 *handshakeV4) init() {
+	if v4.Auth == nil {
+		v4.Auth = func() map[string]interface{} { return map[string]interface{}{} }
+	}
+}
+
 type ServerV4 struct {
 	inSocketV4
 

--- a/server.v4.runback.go
+++ b/server.v4.runback.go
@@ -16,6 +16,7 @@ func doConnectPacketV4(v4 *ServerV4) func(SocketID, siot.Socket, *Request) error
 		v4.setPrefix()
 		v4.setSocketID(socketID)
 		v4.setNsp(socket.Namespace)
+		v4.setHandshake(socket.Data)
 
 		if fn, ok := v4.onConnect[socket.Namespace]; ok {
 			return fn(&SocketV4{inSocketV4: v4.inSocketV4, req: req})

--- a/server.v4.socket.go
+++ b/server.v4.socket.go
@@ -27,6 +27,7 @@ type innTooExceptEmit interface {
 type inSocketV4 struct {
 	onConnect map[Namespace]onConnectCallbackVersion4
 
+	hs   handshakeV4
 	prev inSocketV3
 
 	except []Room
@@ -39,6 +40,12 @@ func (v4 *inSocketV4) clone() inSocketV4 {
 	return rtn
 }
 
+func (v4 *inSocketV4) setHandshake(in interface{}) {
+	switch val := in.(type) {
+	case map[string]interface{}:
+		v4.hs.Auth = func() map[string]interface{} { return val }
+	}
+}
 func (v4 *inSocketV4) setIsServer(isServer bool)     { v4.prev.setIsServer(isServer) }
 func (v4 *inSocketV4) setIsSender(isSender bool)     { v4.prev.setIsSender(isSender) }
 func (v4 *inSocketV4) setSocketID(socketID SocketID) { v4.prev.setSocketID(socketID) }
@@ -154,8 +161,9 @@ type SocketV4 struct {
 	req *Request
 }
 
-func (v4 *SocketV4) ID() SocketID      { return SocketID(v4.prefix()) + v4.socketID() }
-func (v4 *SocketV4) Request() *Request { return v4.req }
+func (v4 *SocketV4) ID() SocketID           { return SocketID(v4.prefix()) + v4.socketID() }
+func (v4 *SocketV4) Request() *Request      { return v4.req }
+func (v4 *SocketV4) Handshake() handshakeV4 { v4.hs.init(); return v4.hs }
 
 func (v4 *SocketV4) Emit(event Event, data ...Data) error {
 	v4.addID(v4.socketID())


### PR DESCRIPTION
This adds handshake data to the SocketV4 struct. This is the initial auth data that is present only in v4. Other data can be back ported to other versions as needed.