### PR TITLE
Update the SIO disconnect packet functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+protocol/socket.io-protocol
+testing

--- a/callback/callback.go
+++ b/callback/callback.go
@@ -15,6 +15,14 @@ func (fn ErrorWrap) Callback(data ...interface{}) error { return fn() }
 func (ErrorWrap) Serialize() (string, error)            { return "", ErrStubSerialize }
 func (ErrorWrap) Unserialize(string) error              { return ErrStubUnserialize }
 
+type FuncAny func(...interface{}) error
+
+func (fn FuncAny) Callback(v ...interface{}) error {
+	return fn(v...)
+}
+func (FuncAny) Serialize() (string, error) { return "", ErrStubSerialize }
+func (FuncAny) Unserialize(string) error   { return ErrStubUnserialize }
+
 type FuncString func(string)
 
 func (fn FuncString) Callback(v ...interface{}) error {

--- a/serialize/serialize.go
+++ b/serialize/serialize.go
@@ -50,6 +50,7 @@ func stringify(val interface{}) string {
 }
 
 var (
+	AnyParam  = _anyWrap{Any(nil)}
 	BinParam  = _binaryWrap{Binary(nil)}
 	ErrParam  = _errorWrap{Error(nil)}
 	F64Param  = _float64Param{Float64(0)}
@@ -58,6 +59,19 @@ var (
 	StrParam  = _stringParam{String("")}
 	UintParam = _uintParam{Uinteger(0)}
 )
+
+type (
+	_any     struct{ a interface{} }
+	_anyWrap struct{ SerializableWrap }
+)
+
+func Any(v interface{}) *_any                      { return &_any{v} }
+func (x *_any) String() (str string)               { str, _ = x.Serialize(); return }
+func (x *_any) Serialize() (str string, err error) { return "", ErrSerializableBinary }
+func (x *_any) Unserialize(str string) (err error) { return ErrSerializableBinary }
+func (x *_any) Interface() (v interface{})         { return x.a }
+func (x _anyWrap) Unserialize(string) error        { return nil }
+func (x _anyWrap) String() string                  { return "" }
 
 type (
 	_binary     struct{ r io.Reader }


### PR DESCRIPTION
The functionality around disconnecting a SIO packet was broken. These changes fix that and allow namespaced and non-namespaced disconnects to happen.