### PR TITLE
Fix binary ws transport and add new callback types

### DIFF
--- a/callback/callback.go
+++ b/callback/callback.go
@@ -17,11 +17,25 @@ func (ErrorWrap) Unserialize(string) error              { return ErrStubUnserial
 
 type FuncAny func(...interface{}) error
 
-func (fn FuncAny) Callback(v ...interface{}) error {
-	return fn(v...)
+func (fn FuncAny) Callback(v ...interface{}) error { return fn(v...) }
+func (FuncAny) Serialize() (string, error)         { return "", ErrStubSerialize }
+func (FuncAny) Unserialize(string) error           { return ErrStubUnserialize }
+
+type FuncAnyAck func(...interface{}) []seri.Serializable
+
+func (fn FuncAnyAck) Callback(v ...interface{}) error { return ErrStubSerialize }
+func (fn FuncAnyAck) CallbackAck(v ...interface{}) []interface{} {
+	slice := fn(v...)
+	out := make([]interface{}, len(v))
+	for i, ice := range slice {
+		if x, ok := ice.(interface{ Interface() interface{} }); ok {
+			out[i] = x.Interface()
+		}
+	}
+	return out
 }
-func (FuncAny) Serialize() (string, error) { return "", ErrStubSerialize }
-func (FuncAny) Unserialize(string) error   { return ErrStubUnserialize }
+func (FuncAnyAck) Serialize() (string, error) { return "", ErrStubSerialize }
+func (FuncAnyAck) Unserialize(string) error   { return ErrStubUnserialize }
 
 type FuncString func(string)
 

--- a/engineio/option.v2.go
+++ b/engineio/option.v2.go
@@ -81,9 +81,13 @@ func WithTransportChannelBuffer(n int) Option {
 
 func WithTransportOption(opts ...eiot.Option) Option {
 	return func(svr Server) {
+	ServerCheck: // makes things an O(2^n) check...
 		switch v := svr.(type) {
 		case *serverV2:
 			v.eto = append(v.eto, opts...)
+		case interface{ prev() Server }:
+			svr = v.prev()
+			goto ServerCheck
 		}
 	}
 }

--- a/engineio/server.v2.go
+++ b/engineio/server.v2.go
@@ -88,6 +88,7 @@ func (v2 *serverV2) new(opts ...Option) *serverV2 {
 	WithTransport("polling", eiot.NewPollingTransport(v2.transportChanBuf))(v2)
 	WithTransport("websocket", eiot.NewWebsocketTransport(v2.transportChanBuf))(v2)
 
+	v2.eto = []eiot.Option{eiot.WithGovernor(1500*time.Microsecond, 500*time.Microsecond)}
 	v2.With(v2, opts...)
 
 	return v2

--- a/engineio/session/manage.go
+++ b/engineio/session/manage.go
@@ -5,18 +5,16 @@ import "time"
 type sessionCtxKey string
 
 const (
-	SessionTimeoutKey        sessionCtxKey = "timeout"
-	SessionIntervalKey       sessionCtxKey = "interval"
-	SessionExtendTimeoutKey  sessionCtxKey = "timeout-extend"
-	SessionExtendIntervalKey sessionCtxKey = "interval-extend"
+	SessionTimeoutKey       sessionCtxKey = "timeout"
+	SessionIntervalKey      sessionCtxKey = "interval"
+	SessionExtendTimeoutKey sessionCtxKey = "timeout-extend"
 
 	SessionCloseChannelKey  sessionCtxKey = "cancel-channel"
 	SessionCloseFunctionKey sessionCtxKey = "cancel-function"
 )
 
 type (
-	TimeoutChannel     func() <-chan struct{}
-	IntervalChannel    func() <-chan time.Time
-	ExtendTimeoutFunc  func()
-	ExtendIntervalFunc func(time.Duration)
+	TimeoutChannel    func() <-chan struct{}
+	IntervalChannel   func() <-chan time.Time
+	ExtendTimeoutFunc func()
 )

--- a/engineio/sessions.go
+++ b/engineio/sessions.go
@@ -130,16 +130,6 @@ func (c *lifecycle) WithInterval(ctx context.Context, d time.Duration) context.C
 	c.id = d
 	c.i.LoadOrStore(sessionID, time.NewTicker(c.id))
 
-	ctx = context.WithValue(ctx, eios.SessionExtendIntervalKey, eios.ExtendIntervalFunc(func(d time.Duration) {
-		if val, ok := c.i.Load(sessionID); ok {
-			if d != 0 {
-				val.(*time.Ticker).Reset(d)
-			} else {
-				val.(*time.Ticker).Reset(c.id)
-			}
-		}
-	}))
-
 	var interval eios.IntervalChannel = func() <-chan time.Time {
 		if val, ok := c.i.Load(sessionID); ok {
 			val.(*time.Ticker).Reset(c.id)

--- a/engineio/transport/option.go
+++ b/engineio/transport/option.go
@@ -1,5 +1,7 @@
 package transport
 
+import "time"
+
 type Option func(Transporter)
 
 func WithCodec(codec Codec) Option {
@@ -34,6 +36,26 @@ func WithNoPing() Option {
 		switch v := t.(type) {
 		case interface{ InnerTransport() *Transport }:
 			v.InnerTransport().sendPing = false
+		}
+	}
+}
+
+func WithBufferedReader() Option {
+	return func(t Transporter) {
+		switch v := t.(type) {
+		// TODO(njones): case *PollingTransport: ...
+		case *WebsocketTransport:
+			v.buffered = true
+		}
+	}
+}
+
+func WithGovernor(minTime, sleep time.Duration) Option {
+	return func(t Transporter) {
+		switch v := t.(type) {
+		case *WebsocketTransport:
+			v.governor.minTime = minTime
+			v.governor.sleep = sleep
 		}
 	}
 }

--- a/server.v4.socket.go
+++ b/server.v4.socket.go
@@ -27,7 +27,6 @@ type innTooExceptEmit interface {
 type inSocketV4 struct {
 	onConnect map[Namespace]onConnectCallbackVersion4
 
-	hs   handshakeV4
 	prev inSocketV3
 
 	except []Room
@@ -40,12 +39,6 @@ func (v4 *inSocketV4) clone() inSocketV4 {
 	return rtn
 }
 
-func (v4 *inSocketV4) setHandshake(in interface{}) {
-	switch val := in.(type) {
-	case map[string]interface{}:
-		v4.hs.Auth = func() map[string]interface{} { return val }
-	}
-}
 func (v4 *inSocketV4) setIsServer(isServer bool)     { v4.prev.setIsServer(isServer) }
 func (v4 *inSocketV4) setIsSender(isSender bool)     { v4.prev.setIsSender(isSender) }
 func (v4 *inSocketV4) setSocketID(socketID SocketID) { v4.prev.setSocketID(socketID) }
@@ -143,6 +136,7 @@ func (v4 inSocketV4) Emit(event Event, data ...Data) error {
 			if id == v1._socketID && !v1.isServer {
 				continue // skip sending back to sender
 			}
+
 			if _, inSet := uniqueID[id]; !inSet {
 				v1.addID(id)
 				uniqueID[id] = struct{}{}
@@ -158,12 +152,13 @@ type onConnectCallbackVersion4 = func(*SocketV4) error
 type SocketV4 struct {
 	inSocketV4
 
+	han handshakeV4
 	req *Request
 }
 
 func (v4 *SocketV4) ID() SocketID           { return SocketID(v4.prefix()) + v4.socketID() }
 func (v4 *SocketV4) Request() *Request      { return v4.req }
-func (v4 *SocketV4) Handshake() handshakeV4 { v4.hs.init(); return v4.hs }
+func (v4 *SocketV4) Handshake() handshakeV4 { v4.han.init(); return v4.han }
 
 func (v4 *SocketV4) Emit(event Event, data ...Data) error {
 	v4.addID(v4.socketID())


### PR DESCRIPTION
This commit fixes returning binary data from an Emit or Ack callback. It also adds an exported generic Callback wrapper that can be used for On events. So callbacks can accept interface parameters if needed. The binary websocket transport can offer a buffered or unbuffered reader.