### PR TITLE
Update functional options

### DIFF
--- a/engineio/option.go
+++ b/engineio/option.go
@@ -1,4 +1,4 @@
-package socketio
+package engineio
 
 import with "github.com/njones/socketio/option"
 

--- a/engineio/option.v2.go
+++ b/engineio/option.v2.go
@@ -8,52 +8,41 @@ import (
 	eiot "github.com/njones/socketio/engineio/transport"
 )
 
-type Option = func(Server)
-
 func WithCodec(codec eiot.Codec) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.codec = codec
 		}
 	}
 }
 
 func WithPath(path string) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.path = &path
 		}
 	}
 }
 
 func WithPingTimeout(d time.Duration) Option {
-	return func(svr Server) {
-	ServerCheck:
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.pingTimeout = d
-		case interface{ prev() Server }:
-			svr = v.prev()
-			goto ServerCheck
 		}
 	}
 }
 
 func WithUpgradeTimeout(d time.Duration) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.upgradeTimeout = d
 		}
 	}
 }
 
 func WithCookie(name, path string, httpOnly bool) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.cookie.name = name
 			v.cookie.path = path
 			v.cookie.httpOnly = httpOnly
@@ -62,32 +51,25 @@ func WithCookie(name, path string, httpOnly bool) Option {
 }
 
 func WithGenerateIDFunc(fn func() SessionID) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.generateID = fn
 		}
 	}
 }
 
 func WithTransportChannelBuffer(n int) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.transportChanBuf = n
 		}
 	}
 }
 
 func WithTransportOption(opts ...eiot.Option) Option {
-	return func(svr Server) {
-	ServerCheck: // makes things an O(2^n) check...
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.eto = append(v.eto, opts...)
-		case interface{ prev() Server }:
-			svr = v.prev()
-			goto ServerCheck
 		}
 	}
 }
@@ -95,38 +77,27 @@ func WithTransportOption(opts ...eiot.Option) Option {
 var clearTransport = new(sync.Once)
 
 func WithTransport(name eiot.Name, tr func(SessionID, eiot.Codec) eiot.Transporter) Option {
-	return func(svr Server) {
-	ServerCheck: // makes things an O(2^n) check...
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			clearTransport.Do(func() {
 				v.transports = make(map[eiot.Name]func(SessionID, eiot.Codec) eiot.Transporter)
 			})
 			v.transports[name] = tr
-		case interface{ prev() Server }:
-			svr = v.prev()
-			goto ServerCheck
 		}
 	}
 }
 
 func WithInitialPackets(fn func(eiot.Transporter, *http.Request)) Option {
-	return func(svr Server) {
-	ServerCheck: // makes things an O(2^n) check...
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.initialPackets = fn
-		case interface{ prev() Server }:
-			svr = v.prev()
-			goto ServerCheck
 		}
 	}
 }
 
 func WithSessionShave(d time.Duration) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV2:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV2); ok {
 			v.sessions.(*sessions).shave = d
 		}
 	}

--- a/engineio/option.v3.go
+++ b/engineio/option.v3.go
@@ -5,14 +5,9 @@ import (
 )
 
 func WithPingInterval(d time.Duration) Option {
-	return func(svr Server) {
-	ServerCheck:
-		switch v := svr.(type) {
-		case *serverV3:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV3); ok {
 			v.pingInterval = d
-		case interface{ prev() Server }:
-			svr = v.prev()
-			goto ServerCheck
 		}
 	}
 }
@@ -40,9 +35,8 @@ func (x CORSmaxAge) val() interface{}               { return int(x) }
 func (x CORSoptionsSuccessStatus) val() interface{} { return int(x) }
 
 func WithCors(opts ...corsOption) Option {
-	return func(svr Server) {
-		switch v := svr.(type) {
-		case *serverV3:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV3); ok {
 			for _, opt := range opts {
 				switch opt.(type) {
 				case CORSenable:

--- a/engineio/option.v4.go
+++ b/engineio/option.v4.go
@@ -1,14 +1,9 @@
 package engineio
 
 func WithMaxPayload(n int) Option {
-	return func(svr Server) {
-	ServerCheck:
-		switch v := svr.(type) {
-		case *serverV4:
+	return func(o OptionWith) {
+		if v, ok := o.(*serverV4); ok {
 			v.maxPayload = n
-		case interface{ prev() Server }:
-			svr = v.prev()
-			goto ServerCheck
 		}
 	}
 }

--- a/engineio/server.go
+++ b/engineio/server.go
@@ -30,6 +30,7 @@ type server interface {
 }
 
 type Server = interface {
+	OptionWith
 	ServeHTTP(http.ResponseWriter, *http.Request)
 }
 

--- a/engineio/server.v2.go
+++ b/engineio/server.v2.go
@@ -59,7 +59,11 @@ type serverV2 struct {
 	transportRunError chan error
 }
 
-func NewServerV2(opts ...Option) Server { return (&serverV2{}).new(opts...) }
+func NewServerV2(opts ...Option) Server {
+	v2 := (&serverV2{}).new(opts...)
+	v2.With(opts...)
+	return v2
+}
 
 func (v2 *serverV2) new(opts ...Option) *serverV2 {
 	v2.path = amp("/engine.io")
@@ -89,14 +93,13 @@ func (v2 *serverV2) new(opts ...Option) *serverV2 {
 	WithTransport("websocket", eiot.NewWebsocketTransport(v2.transportChanBuf))(v2)
 
 	v2.eto = []eiot.Option{eiot.WithGovernor(1500*time.Microsecond, 500*time.Microsecond)}
-	v2.With(v2, opts...)
 
 	return v2
 }
 
-func (v2 *serverV2) With(svr Server, opts ...Option) {
+func (v2 *serverV2) With(opts ...Option) {
 	for _, opt := range opts {
-		opt(svr)
+		opt(v2)
 	}
 }
 

--- a/engineio/server.v3.go
+++ b/engineio/server.v3.go
@@ -37,7 +37,12 @@ type serverV3 struct {
 	}
 }
 
-func NewServerV3(opts ...Option) Server { return (&serverV3{}).new(opts...) }
+func NewServerV3(opts ...Option) Server {
+	v3 := (&serverV3{}).new(opts...)
+	v3.With(opts...)
+
+	return v3
+}
 
 func (v3 *serverV3) new(opts ...Option) *serverV3 {
 	v3.serverV2 = (&serverV2{}).new(opts...)
@@ -59,11 +64,15 @@ func (v3 *serverV3) new(opts ...Option) *serverV3 {
 	}
 	v3.servers[Version3] = v3
 
-	v3.With(v3, opts...)
 	return v3
 }
 
-func (v3 *serverV3) prev() Server { return v3.serverV2 }
+func (v3 *serverV3) With(opts ...Option) {
+	v3.serverV2.With(opts...)
+	for _, opt := range opts {
+		opt(v3)
+	}
+}
 
 func (v3 *serverV3) serveTransport(w http.ResponseWriter, r *http.Request) (transport eiot.Transporter, err error) {
 	ctx := r.Context()

--- a/engineio/server.v5.go
+++ b/engineio/server.v5.go
@@ -50,7 +50,12 @@ type serverV5 struct {
 	*serverV4
 }
 
-func NewServerV5(opts ...Option) Server { return (&serverV5{}).new(opts...) }
+func NewServerV5(opts ...Option) Server {
+	v5 := (&serverV5{}).new(opts...)
+	v5.With(opts...)
+
+	return v5
+}
 
 func (v5 *serverV5) new(opts ...Option) *serverV5 {
 	v5.serverV4 = (&serverV4{}).new(opts...)
@@ -64,8 +69,12 @@ func (v5 *serverV5) new(opts ...Option) *serverV5 {
 
 	v5.servers[Version5] = v5
 
-	v5.With(v5, opts...)
 	return v5
 }
 
-func (v5 *serverV5) prev() Server { return v5.serverV4 }
+func (v5 *serverV5) With(opts ...Option) {
+	v5.serverV4.With(opts...)
+	for _, opt := range opts {
+		opt(v5)
+	}
+}

--- a/engineio/transport/option.go
+++ b/engineio/transport/option.go
@@ -1,12 +1,17 @@
 package transport
 
-import "time"
+import (
+	"time"
 
-type Option func(Transporter)
+	with "github.com/njones/socketio/option"
+)
+
+type Option = with.Option
+type OptionWith = with.OptionWith
 
 func WithCodec(codec Codec) Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
+	return func(o OptionWith) {
+		switch v := o.(type) {
 		case interface{ InnerTransport() *Transport }:
 			v.InnerTransport().codec = codec
 		}
@@ -14,26 +19,24 @@ func WithCodec(codec Codec) Option {
 }
 
 func OnInitProbe(b bool) Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
-		case *WebsocketTransport:
+	return func(o OptionWith) {
+		if v, ok := o.(*WebsocketTransport); ok {
 			v.isInitProbe = b
 		}
 	}
 }
 
 func OnUpgrade(fn func() error) Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
-		case *WebsocketTransport:
+	return func(o OptionWith) {
+		if v, ok := o.(*WebsocketTransport); ok {
 			v.fnOnUpgrade = fn
 		}
 	}
 }
 
 func WithNoPing() Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
+	return func(o OptionWith) {
+		switch v := o.(type) {
 		case interface{ InnerTransport() *Transport }:
 			v.InnerTransport().sendPing = false
 		}
@@ -41,19 +44,16 @@ func WithNoPing() Option {
 }
 
 func WithBufferedReader() Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
-		// TODO(njones): case *PollingTransport: ...
-		case *WebsocketTransport:
+	return func(o OptionWith) {
+		if v, ok := o.(*WebsocketTransport); ok {
 			v.buffered = true
 		}
 	}
 }
 
 func WithGovernor(minTime, sleep time.Duration) Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
-		case *WebsocketTransport:
+	return func(o OptionWith) {
+		if v, ok := o.(*WebsocketTransport); ok {
 			v.governor.minTime = minTime
 			v.governor.sleep = sleep
 		}

--- a/engineio/transport/transport.websocket.go
+++ b/engineio/transport/transport.websocket.go
@@ -55,12 +55,16 @@ func NewWebsocketTransport(chanBuf int) func(SessionID, Codec) Transporter {
 	}
 }
 
-func (t *WebsocketTransport) InnerTransport() *Transport { return t.Transport }
-
-func (t *WebsocketTransport) Run(w http.ResponseWriter, r *http.Request, opts ...Option) (err error) {
+func (t *WebsocketTransport) With(opts ...Option) {
 	for _, opt := range opts {
 		opt(t)
 	}
+}
+
+func (t *WebsocketTransport) InnerTransport() *Transport { return t.Transport }
+
+func (t *WebsocketTransport) Run(w http.ResponseWriter, r *http.Request, opts ...Option) (err error) {
+	t.With(opts...)
 
 	t.conn, err = ws.Accept(w, r, &ws.AcceptOptions{
 		OriginPatterns: t.origin,
@@ -332,9 +336,8 @@ func (t *WebsocketTransport) outgoing(r *http.Request) (err error) {
 }
 
 func WithPerMessageDeflate(kind HTTPCompressionKind) Option {
-	return func(t Transporter) {
-		switch v := t.(type) {
-		case *WebsocketTransport:
+	return func(o OptionWith) {
+		if v, ok := o.(*WebsocketTransport); ok {
 			_ = v
 		}
 	}

--- a/option/option.go
+++ b/option/option.go
@@ -1,0 +1,4 @@
+package option
+
+type Option func(OptionWith)
+type OptionWith interface{ With(...Option) }

--- a/server.v1.new.go
+++ b/server.v1.new.go
@@ -5,7 +5,5 @@ package socketio
 
 // NewServer returns a new v1.0 socketIO server
 func NewServer(opts ...Option) *ServerV1 {
-	v1 := &ServerV1{}
-	v1.new(opts...)
-	return v1
+	return NewServerV1(opts...)
 }

--- a/server.v2.new.go
+++ b/server.v2.new.go
@@ -4,7 +4,5 @@
 package socketio
 
 func NewServer(opts ...Option) *ServerV2 {
-	v2 := &ServerV2{}
-	v2.new(opts...)
-	return v2
+	return NewServerV2(opts...)
 }

--- a/server.v3.new.go
+++ b/server.v3.new.go
@@ -5,7 +5,5 @@
 package socketio
 
 func NewServer(opts ...Option) *ServerV3 {
-	v3 := &ServerV3{}
-	v3.new(opts...)
-	return v3
+	return NewServerV3(opts...)
 }

--- a/server.v4.new.go
+++ b/server.v4.new.go
@@ -5,7 +5,5 @@
 package socketio
 
 func NewServer(opts ...Option) *ServerV4 {
-	v4 := &ServerV4{}
-	v4.new(opts...)
-	return v4
+	return NewServerV4(opts...)
 }

--- a/server.v4.runback.go
+++ b/server.v4.runback.go
@@ -3,7 +3,6 @@ package socketio
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	siop "github.com/njones/socketio/protocol"
 	siot "github.com/njones/socketio/transport"
@@ -64,18 +63,6 @@ func doV4(v4 *ServerV4, socketID SocketID, socket siot.Socket, req *Request) err
 
 		connectResponse := map[string]interface{}{"sid": socketID.String()}
 		v4.tr().Send(socketID, connectResponse, siop.WithType(siop.ConnectPacket.Byte()), siop.WithNamespace(socket.Namespace))
-
-		time.Sleep(600 * time.Microsecond) // wait, wait... what! wait for a 1/2 beat... otherwise it may ship things to fast to the websocket endpoint...
-
-		var data = socket.Data
-		if data == nil {
-			data = map[string]interface{}{}
-		}
-		connectNamespace := []interface{}{"auth", data}
-		v4.tr().Send(socketID, connectNamespace, siop.WithType(siop.EventPacket.Byte()), siop.WithNamespace(socket.Namespace))
-
-		time.Sleep(600 * time.Microsecond) // yup, things were flaky when there wasn't a sleep...
-
 		v4.tr().(rawTransport).Transport(socketID).SendBuffer()
 		return nil
 	}

--- a/transport/filter.go
+++ b/transport/filter.go
@@ -11,7 +11,7 @@ type SocketArray struct {
 	filterToLocalID func(Namespace, SocketID) ([]byte, error)
 }
 
-func InitSocketArray(ns Namespace, ids []SocketID, opts ...func(*SocketArray)) SocketArray {
+func InitSocketArray(ns Namespace, ids []SocketID, opts ...func(optionWith)) SocketArray {
 	array := SocketArray{
 		namespace: ns,
 		socketIDs: ids,
@@ -20,6 +20,12 @@ func InitSocketArray(ns Namespace, ids []SocketID, opts ...func(*SocketArray)) S
 		opt(&array)
 	}
 	return array
+}
+
+func (a *SocketArray) With(opts ...option) {
+	for _, opt := range opts {
+		opt(a)
+	}
 }
 
 func (a SocketArray) IDs() []SocketID { return a.socketIDs }

--- a/transport/option.go
+++ b/transport/option.go
@@ -1,9 +1,14 @@
 package transport
 
-type option func(*SocketArray)
+import with "github.com/njones/socketio/option"
+
+type option = with.Option
+type optionWith = with.OptionWith
 
 func WithSocketRoomFilter(fn func(Namespace, Room, SocketID) (bool, error)) option {
-	return func(ary *SocketArray) {
-		ary.filterOnRoom = fn
+	return func(o optionWith) {
+		if ary, ok := o.(*SocketArray); ok {
+			ary.filterOnRoom = fn
+		}
 	}
 }


### PR DESCRIPTION
Refactor most functional options to use the same underlining interface which will help with inter-op and passing them along. For instance, now a transport functional option can be passed in during the SocketIO server setup. Also, simplified the execution path for applying options previously it was a O(n^n) application process of options. This has been simplified to O(n*m), and gives a much more logical execution path of when an option will be applied.