### PR TITLE
Fix data race conditions all server versions

### DIFF
--- a/server.v1.runback.go
+++ b/server.v1.runback.go
@@ -94,7 +94,7 @@ func doConnectPacket(v1 *ServerV1) func(SocketID, siot.Socket, *Request) error {
 		v1.setNsp(socket.Namespace)
 
 		if fn, ok := v1.onConnect[socket.Namespace]; ok {
-			return fn(&SocketV1{inSocketV1: v1.inSocketV1, req: req, Connected: true})
+			return fn(&SocketV1{inSocketV1: v1.inSocketV1.clone(), req: req, Connected: true})
 		}
 		return ErrBadOnConnectSocket
 	}

--- a/server.v2.socket.go
+++ b/server.v2.socket.go
@@ -27,7 +27,7 @@ func (v2 *inSocketV2) setNsp(namespace Namespace)    { v2.prev.setNsp(namespace)
 func (v2 *inSocketV2) addID(id siot.SocketID)        { v2.prev.addID(id) }
 func (v2 *inSocketV2) addTo(room Room)               { v2.prev.addTo(room) }
 
-func (v2 inSocketV2) tr() siot.Transporter { v1 := v2.prev; return v1.tr() }
+func (v2 inSocketV2) tr() siot.Transporter { return v2.prev.tr() }
 func (v2 inSocketV2) nsp() Namespace       { return v2.prev.nsp() }
 func (v2 inSocketV2) prefix() string       { return v2.prev.prefix() }
 func (v2 inSocketV2) socketID() SocketID   { return v2.prev.socketID() }

--- a/server.v3.go
+++ b/server.v3.go
@@ -43,11 +43,13 @@ func (v3 *ServerV3) new(opts ...Option) Server {
 	v1.run = runV3(v3)
 
 	v1.transport = nmem.NewInMemoryTransport(siop.NewPacketV5)
+	v1.setTransporter(v1.transport)
+
 	v1.protectedEventName = v3ProtectedEventName
 	v1.doConnectPacket = doConnectPacketV3(v3)
 
 	v3.doBinaryAckPacket = doBinaryAckPacket(v1)
-	v3.inSocketV3.prev = v2.inSocketV2
+	v3.inSocketV3.prev = v2.inSocketV2.clone()
 
 	return v3
 }

--- a/server.v4.go
+++ b/server.v4.go
@@ -52,10 +52,12 @@ func (v4 *ServerV4) new(opts ...Option) Server {
 	v1.run = runV4(v4)
 
 	v1.transport = nmem.NewInMemoryTransport(siop.NewPacketV5)
+	v1.setTransporter(v1.transport)
+
 	v1.protectedEventName = v4ProtectedEventName
 	v1.doConnectPacket = doConnectPacketV4(v4)
 
-	v4.inSocketV4.prev = v3.inSocketV3
+	v4.inSocketV4.prev = v3.inSocketV3.clone()
 
 	return v4
 }

--- a/server.v4.socket.go
+++ b/server.v4.socket.go
@@ -46,7 +46,10 @@ func (v4 *inSocketV4) setPrefix()                    { v4.prev.setPrefix() }
 func (v4 *inSocketV4) setNsp(namespace Namespace)    { v4.prev.setNsp(namespace) }
 func (v4 *inSocketV4) addID(id siot.SocketID)        { v4.prev.addID(id) }
 func (v4 *inSocketV4) addTo(room Room)               { v4.prev.addTo(room) }
-func (v4 *inSocketV4) addExcept(room Room)           { v4.except = append(v4.except, room) }
+func (v4 *inSocketV4) addExcept(room Room) {
+	defer v4.prev.prev.prev.l()()
+	v4.except = append(v4.except, room)
+}
 
 func (v4 inSocketV4) tr() siot.Transporter { return v4.prev.tr() }
 func (v4 inSocketV4) nsp() Namespace       { return v4.prev.nsp() }


### PR DESCRIPTION
Fix  Data Race Conditions in all Server Versions

When the tests for websockets were added, it exposed a Data Race that could happen when using the inSocketV(x) data structures. A RWMutex was added to guard access around the fields that could cause trouble. Also the tests were updated to increment counters using atomic to prevent race conditions within the test code. There needed to be atomic access around the interval duration in the sessions management code for EIO transports. This is a wrapper around int64 atomic code.