### PR TITLE
Standardize error naming and text

### DIFF
--- a/adaptor/transport/memory/error.go
+++ b/adaptor/transport/memory/error.go
@@ -6,6 +6,6 @@ import (
 
 // All of the possible errors the map transport can return
 const (
-	ErrInvalidSocketTransport erro.String = "invalid %s transport for socket"
-	ErrNilTransporter         erro.String = "cannot add a nil transporter"
+	ErrSocketIDTransportNotFound erro.StringF = "socket id %q not found in the in-memory map"
+	ErrNilTransporter            erro.String  = "expected a type of Transporter, found <nil>"
 )

--- a/adaptor/transport/memory/transport.go
+++ b/adaptor/transport/memory/transport.go
@@ -121,11 +121,12 @@ func (tr *inMemoryTransport) Send(socketID SocketID, data Data, opts ...Option) 
 	tr.ṡ.Lock()
 	defer tr.ṡ.Unlock()
 
-	if _, ok := tr.s[socketID]; ok {
-		tr.s[socketID].Send(data, opts...)
-		return nil
+	if _, ok := tr.s[socketID]; !ok {
+		return ErrSocketIDTransportNotFound.F(socketID.String())
 	}
-	return ErrInvalidSocketTransport.F("map")
+
+	tr.s[socketID].Send(data, opts...)
+	return nil
 }
 
 // namespace/socketID to room relationship

--- a/callback/callback.go
+++ b/callback/callback.go
@@ -12,18 +12,18 @@ import (
 type ErrorWrap func() error
 
 func (fn ErrorWrap) Callback(data ...interface{}) error { return fn() }
-func (ErrorWrap) Serialize() (string, error)            { return "", ErrStubSerialize }
-func (ErrorWrap) Unserialize(string) error              { return ErrStubUnserialize }
+func (ErrorWrap) Serialize() (string, error)            { return "", ErrUnimplementedSerialize }
+func (ErrorWrap) Unserialize(string) error              { return ErrUnimplementedUnserialize }
 
 type FuncAny func(...interface{}) error
 
 func (fn FuncAny) Callback(v ...interface{}) error { return fn(v...) }
-func (FuncAny) Serialize() (string, error)         { return "", ErrStubSerialize }
-func (FuncAny) Unserialize(string) error           { return ErrStubUnserialize }
+func (FuncAny) Serialize() (string, error)         { return "", ErrUnimplementedSerialize }
+func (FuncAny) Unserialize(string) error           { return ErrUnimplementedUnserialize }
 
 type FuncAnyAck func(...interface{}) []seri.Serializable
 
-func (fn FuncAnyAck) Callback(v ...interface{}) error { return ErrStubSerialize }
+func (fn FuncAnyAck) Callback(v ...interface{}) error { return ErrUnimplementedSerialize }
 func (fn FuncAnyAck) CallbackAck(v ...interface{}) []interface{} {
 	slice := fn(v...)
 	out := make([]interface{}, len(v))
@@ -34,8 +34,8 @@ func (fn FuncAnyAck) CallbackAck(v ...interface{}) []interface{} {
 	}
 	return out
 }
-func (FuncAnyAck) Serialize() (string, error) { return "", ErrStubSerialize }
-func (FuncAnyAck) Unserialize(string) error   { return ErrStubUnserialize }
+func (FuncAnyAck) Serialize() (string, error) { return "", ErrUnimplementedSerialize }
+func (FuncAnyAck) Unserialize(string) error   { return ErrUnimplementedUnserialize }
 
 type FuncString func(string)
 
@@ -50,8 +50,8 @@ func (fn FuncString) Callback(v ...interface{}) error {
 	}
 	return nil
 }
-func (FuncString) Serialize() (string, error) { return "", ErrStubSerialize }
-func (FuncString) Unserialize(string) error   { return ErrStubUnserialize }
+func (FuncString) Serialize() (string, error) { return "", ErrUnimplementedSerialize }
+func (FuncString) Unserialize(string) error   { return ErrUnimplementedUnserialize }
 
 type Wrap struct {
 	Func       func() interface{} // func([T]...) error
@@ -76,15 +76,15 @@ func (fn Wrap) Callback(data ...interface{}) (err error) {
 	f := reflect.ValueOf(fn.Func())
 
 	if len(data) != f.Type().NumIn() {
-		return ErrInvalidDataInParams
+		return ErrUnexpectedDataInParams.F(len(data), f.Type().NumIn())
 	}
 
 	if len(fn.Parameters) != f.Type().NumIn() {
-		return ErrInvalidFuncInParams
+		return ErrUnexpectedFuncInParams.F(len(fn.Parameters), f.Type().NumIn())
 	}
 
 	if f.Type().NumOut() != 1 {
-		return ErrSingleOutParam
+		return ErrUnexpectedSingleOutParam.F(f.Type().NumOut())
 	}
 
 	type inter interface{ Interface() interface{} }
@@ -119,5 +119,5 @@ func (fn Wrap) Callback(data ...interface{}) (err error) {
 	return nil
 }
 
-func (Wrap) Serialize() (string, error) { return "", ErrStubSerialize }
-func (Wrap) Unserialize(string) error   { return ErrStubUnserialize }
+func (Wrap) Serialize() (string, error) { return "", ErrUnimplementedSerialize }
+func (Wrap) Unserialize(string) error   { return ErrUnimplementedUnserialize }

--- a/callback/error.go
+++ b/callback/error.go
@@ -5,13 +5,11 @@ import (
 )
 
 const (
-	ErrStubSerialize   erro.String = "no Serialize() is a callback function"
-	ErrStubUnserialize erro.String = "no Unserialize() is a callback function"
-
-	ErrInvalidDataInParams erro.String = "the data coming in is not the same as the passed in parameters"
-	ErrInvalidFuncInParams erro.String = "need pass in the same number of parameters as the passed in function"
-	ErrSingleOutParam      erro.String = "need to have a single error output for the passed in function"
-	ErrBadParamType        erro.String = "bad type for parameter"
-	ErrInterfaceNotFound   erro.String = "need to have interface for serialize"
-	ErrUnknownPanic        erro.String = "unknown panic"
+	ErrUnimplementedSerialize   erro.String  = "unimplemented Serialize() method"
+	ErrUnimplementedUnserialize erro.String  = "unimplemented Unserialize() method"
+	ErrUnexpectedDataInParams   erro.StringF = "expected %d callback input parameters, found %d"
+	ErrUnexpectedFuncInParams   erro.StringF = "expected %d wrap.Parameter values, found %d"
+	ErrUnexpectedSingleOutParam erro.StringF = "expected a single error return parameter, found %d return parameters"
+	ErrUnknownPanic             erro.String  = "unknown panic"
+	ErrInterfaceNotFound        erro.String  = "interface not found for serialize"
 )

--- a/engineio/error.go
+++ b/engineio/error.go
@@ -7,26 +7,23 @@ import (
 )
 
 const (
-	ErrNoTransport        erro.String = "transport unknown"
-	ErrNoSessionID        erro.String = "session id unknown"
-	ErrNoEIOVersion       erro.String = "eio version unknown"
-	ErrBadHandshakeMethod erro.String = "bad handshake method"
-	ErrBadRequestMethod   erro.String = "bad http request method"
-	ErrURIPath            erro.String = "bad URI path"
-	ErrTransportRun       erro.String = "bad transport run: %w"
-	ErrPayloadEncode      erro.String = "bad payload encode: %w"
+	ErrUnknownTransport  erro.String = "unknown transport"
+	ErrUnknownSessionID  erro.String = "unknown session id"
+	ErrUnknownEIOVersion erro.String = "unknown engineio version"
+	ErrRequestHTTPMethod erro.String = "invalid request, an unimplemented HTTP method"
+	ErrURIPath           erro.String = "invalid URI path, the prefix is not found"
+
+	EOH erro.String = "End Of Handshake"
+	IOR erro.String = "Is OPTION Request"
 )
 
 const HTTPStatusError400 httpErrorStatus = 400
 
-var ErrBadUpgrade = httpError{400, "transport upgrade error"}
-
-const EOH erro.String = "end of handshake"
-const IOR erro.String = "is OPTION request"
+var ErrBadUpgrade = httpError{400, "failed to upgrade transport"}
 
 type httpErrorStatus int
 
-func (e httpErrorStatus) Error() string { return fmt.Sprintf("http error: %d", e) }
+func (e httpErrorStatus) Error() string { return fmt.Sprintf("HTTP status: %d", e) }
 
 type httpError struct {
 	status int

--- a/engineio/protocol/error.go
+++ b/engineio/protocol/error.go
@@ -2,18 +2,19 @@ package protocol
 
 import erro "github.com/njones/socketio/internal/errors"
 
-const (
-	ErrInvalidRune        erro.String = "invalid rune"
-	ErrInvalidPacketType  erro.String = "invalid packet type: %s"
-	ErrInvalidPacketData  erro.String = "invalid packet data: %s"
-	ErrInvalidHandshake   erro.String = "[%s] invalid handshake data"
-	ErrHandshakeDecode    erro.String = "[%s] handshake decode: %w"
-	ErrHandshakeEncode    erro.String = "[%s] handshake encode: %w"
-	ErrPacketDecode       erro.String = "[%s] packet decode: %w"
-	ErrPacketEncode       erro.String = "[%s] packet encode: %w"
-	ErrPayloadDecode      erro.String = "[%s] payload decode: %w"
-	ErrPayloadEncode      erro.String = "[%s] payload encode: %w"
-	ErrBuffReaderRequired erro.String = "please use a *bufio.Reader"
+func kv(v ...interface{}) erro.Struct { return erro.KV(v...) }
 
-	EOR erro.String = "End Of Record: %w"
+const ver = "version"
+
+const (
+	ErrUnexpectedPacketType  erro.StringF = "unexpected packet type %s"
+	ErrUnexpectedPacketData  erro.StringF = "unexpected packet data %s"
+	ErrUnexpectedHandshake   erro.StringF = "expected %s, found %T"
+	ErrDecodeHandshakeFailed erro.StringF = "failed to decode handshake:: %w"
+	ErrEncodeHandshakeFailed erro.StringF = "failed to encode handshake:: %w"
+	ErrDecodePacketFailed    erro.StringF = "failed to decode packet:: %w"
+	ErrEncodePacketFailed    erro.StringF = "failed to encode packet:: %w"
+	ErrDecodePayloadFailed   erro.StringF = "failed to decode payload:: %w"
+	ErrEncodePayloadFailed   erro.StringF = "failed to encode payload:: %w"
+	EOR                      erro.StringF = "End Of Record: %w"
 )

--- a/engineio/protocol/packet.v2_test.go
+++ b/engineio/protocol/packet.v2_test.go
@@ -219,7 +219,7 @@ func TestPacketV2(t *testing.T) {
 			))
 
 			asString := `0{"sid":"abc1`
-			err := ErrHandshakeDecode.F("v2", io.ErrUnexpectedEOF)
+			err := ErrDecodeHandshakeFailed.F(io.ErrUnexpectedEOF).KV(ver, "v2")
 			return PacketV2{}, asString, err
 		},
 		"Err PacketType": func(*testing.T) (PacketV2, string, error) {
@@ -231,7 +231,7 @@ func TestPacketV2(t *testing.T) {
 			))
 
 			asPacket := PacketV2{Packet{T: 200, D: nil}}
-			err := ErrInvalidPacketType
+			err := ErrUnexpectedPacketType
 			return asPacket, "", err
 		},
 	}

--- a/engineio/protocol/payload.v2.go
+++ b/engineio/protocol/payload.v2.go
@@ -64,22 +64,22 @@ func (enc *PayloadEncoderV2) writePacketLen(packet Packet) (err error) {
 	messageTypeLen := len(packet.T.Bytes())
 	switch data := packet.D.(type) {
 	case string:
-		enc.write.Bytes([]byte(strconv.Itoa(len([]rune(data))+messageTypeLen))).OnErrF(ErrPayloadEncode, "v2", enc.write.Err())
+		enc.write.Bytes([]byte(strconv.Itoa(len([]rune(data))+messageTypeLen))).OnErrF(ErrEncodePayloadFailed, enc.write.Err(), kv(ver, "v2"))
 	case []byte:
-		enc.write.Bytes([]byte(strconv.Itoa(len(data)+messageTypeLen))).OnErrF(ErrPayloadEncode, "v2", enc.write.Err())
+		enc.write.Bytes([]byte(strconv.Itoa(len(data)+messageTypeLen))).OnErrF(ErrEncodePayloadFailed, enc.write.Err(), kv(ver, "v2"))
 	case useLen:
-		enc.write.Bytes([]byte(strconv.Itoa(data.Len()+messageTypeLen))).OnErrF(ErrPayloadEncode, "v2", enc.write.Err())
+		enc.write.Bytes([]byte(strconv.Itoa(data.Len()+messageTypeLen))).OnErrF(ErrEncodePayloadFailed, enc.write.Err(), kv(ver, "v2"))
 	default:
-		enc.write.Bytes([]byte(strconv.Itoa(messageTypeLen))).OnErrF(ErrPayloadEncode, "v2", enc.write.Err())
+		enc.write.Bytes([]byte(strconv.Itoa(messageTypeLen))).OnErrF(ErrEncodePayloadFailed, enc.write.Err(), kv(ver, "v2"))
 	}
-	enc.write.Byte(':').OnErr(ErrPayloadEncode)
+	enc.write.Byte(':').OnErrF(ErrEncodePayloadFailed, kv(ver, "v2"))
 
 	return enc.write.Err()
 }
 
 func (enc *PayloadEncoderV2) writePacket(packet PacketV2) (err error) {
 	if err := NewPacketEncoderV2(enc.write).Encode(packet); err != nil {
-		return ErrPayloadEncode.F("v2", err)
+		return ErrEncodePayloadFailed.F(err).KV(ver, "v2")
 	}
 	return enc.write.Err()
 }

--- a/engineio/protocol/payload.v3.go
+++ b/engineio/protocol/payload.v3.go
@@ -75,7 +75,7 @@ var NewPayloadEncoderV3 _payloadEncoderV3 = func(w io.Writer) *PayloadEncoderV3 
 func (enc *PayloadEncoderV3) Encode(payload PayloadV3) error {
 	for _, packet := range payload {
 		if err := enc.encode(packet); err != nil {
-			return ErrPayloadEncode.F("v3", err)
+			return ErrEncodePayloadFailed.F(err).KV(ver, "v3")
 		}
 	}
 	return enc.write.Err()
@@ -98,7 +98,7 @@ func (enc *PayloadEncoderV3) encode(packet PacketV3) error {
 
 	enc.write.String(fmt.Sprintf("%d:%s", packet.Len()+lenBuf, binaryB))
 	if err := NewPacketEncoderV3(enc.write).Encode(packet); err != nil {
-		return ErrPayloadEncode.F("v3", err)
+		return ErrEncodePayloadFailed.F(err).KV(ver, "v3")
 	}
 	return nil
 }

--- a/engineio/protocol/payload.v4.go
+++ b/engineio/protocol/payload.v4.go
@@ -51,10 +51,10 @@ var NewPayloadEncoderV4 _payloadEncoderV4 = func(w io.Writer) *PayloadEncoderV4 
 func (enc *PayloadEncoderV4) Encode(payload PayloadV4) error {
 	for i, packet := range payload {
 		if i > 0 {
-			enc.write.Byte(RecordSeparator).OnErr(ErrPayloadEncode)
+			enc.write.Byte(RecordSeparator).OnErrF(ErrEncodePayloadFailed)
 		}
 		if err := enc.encode(packet); err != nil {
-			return ErrPayloadEncode.F("v4", err)
+			return ErrEncodePayloadFailed.F(err).KV(ver, "v4")
 		}
 	}
 	return enc.write.Err()
@@ -62,7 +62,7 @@ func (enc *PayloadEncoderV4) Encode(payload PayloadV4) error {
 
 func (enc *PayloadEncoderV4) encode(packet PacketV4) error {
 	if err := NewPacketEncoderV4(enc.write).Encode(packet); err != nil {
-		return ErrPayloadEncode.F("v4", err)
+		return ErrEncodePayloadFailed.F(err).KV(ver, "v4")
 	}
 	return nil
 }

--- a/engineio/server.v2.go
+++ b/engineio/server.v2.go
@@ -113,7 +113,7 @@ func (v2 *serverV2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 HandleError:
 	if err != nil {
 		switch {
-		case errors.Is(err, ErrBadRequestMethod):
+		case errors.Is(err, ErrRequestHTTPMethod):
 			return
 		}
 		return
@@ -136,18 +136,18 @@ func (v2 *serverV2) ServeTransport(w http.ResponseWriter, r *http.Request) (eiot
 		}
 		fallthrough
 	default:
-		return nil, ErrBadRequestMethod
+		return nil, ErrRequestHTTPMethod
 	}
 
 	eioVersion := eioVersionFrom(r)
 	server, ok := v2.servers[eioVersion]
 	if !ok || eioVersion == "" {
-		return nil, ErrNoEIOVersion
+		return nil, ErrUnknownEIOVersion
 	}
 
 	transportName := transportNameFrom(r)
 	if _, ok := v2.transports[transportName]; !ok || transportName == "" {
-		return nil, ErrNoTransport
+		return nil, ErrUnknownTransport
 	}
 
 	ctx := r.Context()

--- a/engineio/sessions.go
+++ b/engineio/sessions.go
@@ -72,7 +72,7 @@ func (t *transport) Get(sessionID SessionID) (eiot.Transporter, error) {
 		return tr, nil
 	}
 
-	return nil, ErrNoSessionID
+	return nil, ErrUnknownSessionID
 }
 
 type lifecycle struct {

--- a/engineio/transport/error.go
+++ b/engineio/transport/error.go
@@ -3,9 +3,9 @@ package transport
 import erro "github.com/njones/socketio/internal/errors"
 
 const (
-	ErrTransportDecode   erro.String = "[%s] transport decode: %w"
-	ErrTransportEncode   erro.String = "[%s] transport encode: %w"
-	ErrUnsupportedMethod erro.String = "%s not supported"
-	ErrCloseSocket       erro.String = "close socket"
-	ErrTimeoutSocket     erro.String = "socket timeout"
+	ErrDecodeFailed        erro.StringF = "failed to decode the %q transport:: %w"
+	ErrEncodeFailed        erro.StringF = "failed to encode the %q transport:: %w"
+	ErrUnimplementedMethod erro.StringF = "unimplemented %s method"
+	ErrCloseSocket         erro.String  = "socket: closed"
+	ErrTimeoutSocket       erro.String  = "socket: timeout"
 )

--- a/engineio/transport/transport.polling.go
+++ b/engineio/transport/transport.polling.go
@@ -170,7 +170,7 @@ Write:
 		if len(packets) > 0 {
 			if err := t.codec.PayloadEncoder.To(w).WritePayload(packets); err != nil {
 				t.send <- eiop.Packet{T: eiop.NoopPacket, D: socketClose{err}}
-				return ErrTransportEncode.F("polling", err)
+				return ErrEncodeFailed.F("polling", err)
 			}
 		}
 	}
@@ -185,7 +185,7 @@ func (t *PollingTransport) emit(w http.ResponseWriter, r *http.Request) error {
 	var payload eiop.Payload
 	if err := t.codec.PayloadDecoder.From(r.Body).ReadPayload(&payload); err != nil {
 		t.send <- eiop.Packet{T: eiop.NoopPacket, D: socketClose{err}}
-		return ErrTransportDecode.F("polling", err)
+		return ErrDecodeFailed.F("polling", err)
 	}
 
 Read:

--- a/engineio/transport/utility.http.go
+++ b/engineio/transport/utility.http.go
@@ -24,7 +24,7 @@ func (wr *writer) WriteHeader(s int) {
 func (w *writer) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	h, ok := w.ResponseWriter.(http.Hijacker)
 	if !ok {
-		return nil, nil, ErrUnsupportedMethod.F("hijack")
+		return nil, nil, ErrUnimplementedMethod.F("http.Hijacker()")
 	}
 	return h.Hijack()
 }

--- a/error.go
+++ b/error.go
@@ -4,30 +4,18 @@ import (
 	erro "github.com/njones/socketio/internal/errors"
 )
 
+const ver = "version"
+
 const (
-	ErrBadScrub                  erro.String = "bad scrub to string: %w"
-	ErrBadEventName              erro.String = "bad event name: %s"
-	ErrInvalidData               erro.String = "invalid data type: %s"
-	ErrInvalidEventName          erro.String = "invalid event name, cannot use the registered name %q"
-	ErrInvalidPacketType         erro.String = "invalid %s packet type: %#v"
-	ErrInvalidPacketTypeExpected erro.String = "event packet invalid type: %T expected binary or string array"
-	ErrNamespaceNotFound         erro.String = "namespace not found: %q"
-
-	ErrStubSerialize   erro.String = "no Serialize() is a callback function"
-	ErrStubUnserialize erro.String = "no Unserialize() is a callback function"
-
-	ErrInvalidDataInParams erro.String = "the data coming in is not the same as the passed in parameters"
-	ErrInvalidFuncInParams erro.String = "need pass in the same number of parameters as the passed in function"
-	ErrSingleOutParam      erro.String = "need to have a single error output for the passed in function"
-	ErrBadParamType        erro.String = "bad type for parameter"
-	ErrInterfaceNotFound   erro.String = "need to have interface for serialize"
-	ErrUnknownPanic        erro.String = "unknown panic"
-
-	ErrOnBinaryEvent erro.String = "binary event: %v"
-
-	ErrBadSendToSocketIndex  erro.String = "the index is invalid"
-	ErrBadOnConnectSocket    erro.String = "bad onconnect socket"
-	ErrBadOnDisconnectSocket erro.String = "bad ondisconnect socket"
-
-	ErrFromRoom erro.String = "bad from room: %w"
+	ErrScrubFailed            erro.StringF = "failed to scrub string:: %w"
+	ErrFromRoomFailed         erro.StringF = "failed to get socket ids from room:: %w"
+	ErrUnknownEventName       erro.String  = "unknown event name, the first field is not a string"
+	ErrUnknownBinaryEventName erro.StringF = "unknown event name, expected a string but found %v (%[1]T)"
+	ErrUnsupportedEventName   erro.StringF = "event name unsupported, cannot use the registered name %q as an event name"
+	ErrUnexpectedData         erro.StringF = "expected an []interface{} or []string, found %T"
+	ErrUnexpectedBinaryData   erro.StringF = "expected an []interface{} (binary array) or []string, found %T"
+	ErrUnexpectedPacketType   erro.StringF = "unexpected %T"
+	ErrNamespaceNotFound      erro.StringF = "namespace %q not found"
+	ErrOnConnectSocket        erro.String  = "socket: invalid onconnect"
+	ErrOnDisconnectSocket     erro.String  = "socket: invalid ondisconnect"
 )

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,5 +1,24 @@
 package errors
 
+/*
+Common wordings for Errors
+
+State - error as a state
+  - "<type>: <state>"
+
+Noun - A single thing (use present tense)
+  - "unimplemented <type>"
+  - "invalid <type>, the <reason>"
+
+Verb - An action (use past tense)
+  - "unexpected <issue>"               [equality]
+  - "expected <state>, found <issue>"  [equality]
+  - "failed to <action>:: <error>"
+  - "unknown <reason>"
+  - "<type> unsupported, <reason>"
+  - "<type> not found (for <reason> | in <type>)"
+*/
+
 import (
 	"context"
 	"errors"
@@ -7,7 +26,12 @@ import (
 	"strings"
 )
 
+func KV(kv ...interface{}) Struct { return Struct{kv: kv} }
+
 type (
+	HTTPErrorStringF string
+	StringF          string
+
 	HTTPErrorString string
 
 	String string
@@ -19,19 +43,18 @@ type (
 	}
 )
 
-func (e HTTPErrorString) As(v interface{}) bool {
+func (e HTTPErrorStringF) As(v interface{}) bool {
 	if str, ok := v.(string); ok {
 		return strings.HasPrefix(string(e), str)
 	}
 	return false
 }
-func (e HTTPErrorString) Error() string               { return string(e) }
-func (e HTTPErrorString) F(v ...interface{}) Struct   { return String(e).F(v...) }
-func (e HTTPErrorString) KV(kv ...interface{}) Struct { return String(e).KV(kv...) }
+func (e HTTPErrorStringF) Error() string               { return string(e) }
+func (e HTTPErrorStringF) F(v ...interface{}) Struct   { return StringF(e).F(v...) }
+func (e HTTPErrorStringF) KV(kv ...interface{}) Struct { return String(e).KV(kv...) }
 
-func (e String) Error() string { return string(e) }
-
-func (e String) F(v ...interface{}) Struct {
+func (e StringF) Error() string { return string(e) }
+func (e StringF) F(v ...interface{}) Struct {
 	var (
 		f  [][]interface{}
 		kv []interface{}
@@ -58,7 +81,20 @@ func (e String) F(v ...interface{}) Struct {
 
 	return Struct{e: e, rr: err, f: f, kv: kv, wrap: errs}
 }
+func (e StringF) KV(kv ...interface{}) Struct {
+	return Struct{e: e, rr: e, kv: kv}
+}
 
+func (e HTTPErrorString) As(v interface{}) bool {
+	if str, ok := v.(string); ok {
+		return strings.HasPrefix(string(e), str)
+	}
+	return false
+}
+func (e HTTPErrorString) Error() string               { return string(e) }
+func (e HTTPErrorString) KV(kv ...interface{}) Struct { return String(e).KV(kv...) }
+
+func (e String) Error() string { return string(e) }
 func (e String) KV(kv ...interface{}) Struct {
 	return Struct{e: e, rr: e, kv: kv}
 }

--- a/internal/readwriter/read.go
+++ b/internal/readwriter/read.go
@@ -9,14 +9,14 @@ import (
 )
 
 type rdrErr interface {
-	OnErr(errs.String)
-	OnErrF(errs.String, ...interface{})
+	OnErr(error)
+	OnErrF(errs.StringF, ...interface{})
 }
 
 type rdrCondErr interface {
 	rdrCondBool
-	OnErr(errs.String) rdrCondBool
-	OnErrF(errs.String, ...interface{}) rdrCondBool
+	OnErr(error) rdrCondBool
+	OnErrF(errs.StringF, ...interface{}) rdrCondBool
 }
 
 type rdrCondBool interface {
@@ -40,15 +40,15 @@ func (rdr *Reader) ConvertErr(from, to error) *Reader {
 	}
 	return rdr
 }
-func (rdr *Reader) OnErr(errs.String)                  {}
-func (rdr *Reader) OnErrF(errs.String, ...interface{}) {}
-func (rdr *Reader) IsErr() bool                        { return rdr.err != nil }
-func (rdr *Reader) IsNotErr() bool                     { return rdr.err == nil }
-func (rdr *Reader) Read(p []byte) (n int, err error)   { return rdr.r.Read(p) }
+func (rdr *Reader) OnErr(error)                         {}
+func (rdr *Reader) OnErrF(errs.StringF, ...interface{}) {}
+func (rdr *Reader) IsErr() bool                         { return rdr.err != nil }
+func (rdr *Reader) IsNotErr() bool                      { return rdr.err == nil }
+func (rdr *Reader) Read(p []byte) (n int, err error)    { return rdr.r.Read(p) }
 
 type readerCond struct{ *Reader }
 
-func (rdr readerCond) OnErr(errs.String) rdrCondBool                  { return rdr }
-func (rdr readerCond) OnErrF(errs.String, ...interface{}) rdrCondBool { return rdr }
+func (rdr readerCond) OnErr(error) rdrCondBool                         { return rdr }
+func (rdr readerCond) OnErrF(errs.StringF, ...interface{}) rdrCondBool { return rdr }
 
 func NewReader(r io.Reader) *Reader { return &Reader{r: bufio.NewReader(r)} }

--- a/internal/readwriter/read.method.go
+++ b/internal/readwriter/read.method.go
@@ -35,12 +35,12 @@ func (rdr *Reader) CopyN(w io.Writer, n int64) rdrErr {
 
 type onRdrErr struct{ *Reader }
 
-func (e onRdrErr) OnErr(err errs.String) {
+func (e onRdrErr) OnErr(err error) {
 	if e.err != nil {
 		e.err = err
 	}
 }
-func (e onRdrErr) OnErrF(err errs.String, v ...interface{}) {
+func (e onRdrErr) OnErrF(err errs.StringF, v ...interface{}) {
 	if e.err != nil {
 		e.err = err.F(v...)
 	}
@@ -48,12 +48,12 @@ func (e onRdrErr) OnErrF(err errs.String, v ...interface{}) {
 
 type condErr struct{ onRdrErr }
 
-func (e condErr) OnErr(err errs.String) rdrCondBool {
+func (e condErr) OnErr(err error) rdrCondBool {
 	e.onRdrErr.OnErr(err)
 	return e
 }
 
-func (e condErr) OnErrF(err errs.String, v ...interface{}) rdrCondBool {
+func (e condErr) OnErrF(err errs.StringF, v ...interface{}) rdrCondBool {
 	e.onRdrErr.OnErrF(err, v...)
 	return e
 }

--- a/internal/readwriter/write.go
+++ b/internal/readwriter/write.go
@@ -8,8 +8,8 @@ import (
 )
 
 type wtrErr interface {
-	OnErr(errs.String)
-	OnErrF(errs.String, ...interface{})
+	OnErr(error)
+	OnErrF(errs.StringF, ...interface{})
 }
 
 type Writer struct {
@@ -26,8 +26,8 @@ func (wtr *Writer) Err() error {
 	}
 	return wtr.err
 }
-func (wtr *Writer) OnErr(errs.String)                  {}
-func (wtr *Writer) OnErrF(errs.String, ...interface{}) {}
+func (wtr *Writer) OnErr(error)                         {}
+func (wtr *Writer) OnErrF(errs.StringF, ...interface{}) {}
 
 func (wtr *Writer) Write(p []byte) (n int, err error) { return wtr.w.Write(p) }
 

--- a/internal/readwriter/write.method.go
+++ b/internal/readwriter/write.method.go
@@ -66,12 +66,12 @@ func (wtr *Writer) Multi(ww ...io.Writer) *Writer {
 
 type onWtrErr struct{ *Writer }
 
-func (e onWtrErr) OnErr(err errs.String) {
+func (e onWtrErr) OnErr(err error) {
 	if e.err != nil {
 		e.err = err
 	}
 }
-func (e onWtrErr) OnErrF(err errs.String, v ...interface{}) {
+func (e onWtrErr) OnErrF(err errs.StringF, v ...interface{}) {
 	if e.err != nil {
 		e.err = err.F(v...)
 	}

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -9,32 +9,21 @@ import (
 
 // All of the errors that can happen while reading or writing socket.io packets
 const (
-	ErrOnReadSoBuffer errsPacket = "error reading packet type %s, save for buffer"
-
-	ErrBadRead    erro.String = "bad read of bytes: %w"
-	ErrShortRead  erro.String = "short read"
-	ErrShortWrite erro.String = "short write"
-
-	ErrEmptyDataArray          erro.String = "empty data array"
-	ErrEmptyDataObject         erro.String = "empty data object"
-	ErrNoAckID                 erro.String = "no ackID found"
-	ErrPacketDataNotWritable   erro.String = "no data io.writer found"
-	ErrUnexpectedAttachmentEnd erro.String = "unexpected attachment end"
-
-	ErrUnexpectedJSONEnd  erro.String = "unexpected end of JSON input"
-	ErrBadMarshal         erro.String = "data marshal: %w"
-	ErrBadUnmarshal       erro.String = "data unmarshal: %w"
-	ErrBadBinaryMarshal   erro.String = "binary data marshal: %w"
-	ErrBadBinaryUnmarshal erro.String = "binary data unmarshal: %w"
-	ErrBadParse           erro.String = "%s int parse: %w"
-
-	ErrBinaryDataUnsupported erro.String = "binary data for this version is unsupported"
-	ErrInvalidPacketType     erro.String = "the data packet type %T does not exist"
-
-	ErrBadInitialFieldUnmarshal erro.String = "bad initial unmarshal of packet field data: %w"
-	ErrBadFieldBase64Decode     erro.String = "bad base64 decode of field string for msgpack: %w"
-	ErrBadFieldMsgPackDecode    erro.String = "bad msgpack decode of field string for msgpack: %w"
-	ErrBadFieldMsgPackEncode    erro.String = "bad msgpack encode of field string for msgpack: %w"
+	ErrReadFailed                  erro.StringF = "failed to read bytes:: %w"
+	ErrUnmarshalInitialFieldFailed erro.StringF = "failed to unmarshal initial fields:: %w"
+	ErrMarshalDataFailed           erro.StringF = "failed to marshal data:: %w"
+	ErrUnmarshalDataFailed         erro.StringF = "failed to unmarshal data:: %w"
+	ErrMarshalBinaryDataFailed     erro.StringF = "failed to marshal binary data:: %w"
+	ErrUnmarshalBinaryDataFailed   erro.StringF = "failed to unmarshal binary data:: %w"
+	ErrParseIntFailed              erro.StringF = "failed to parse int (%s):: %w"
+	ErrUnexpectedPacketType        erro.StringF = "unexpected data type %T"
+	ErrUnexpectedAttachmentEnd     erro.String  = "unexpected attachment end"
+	ErrUnexpectedJSONEnd           erro.String  = "unexpected JSON end"
+	ErrBinaryDataUnsupported       erro.String  = "binary data unsupported in this version"
+	ErrReadUseBuffer               errsPacket   = "%s: read buffer"
+	ErrShortRead                   erro.String  = "read: short"
+	ErrShortWrite                  erro.String  = "write: short"
+	ErrEmptyDataArray              erro.String  = "data array: empty"
 )
 
 // errsPacket is an error type that can send back PacketError errors.

--- a/protocol/error.msgpack.go
+++ b/protocol/error.msgpack.go
@@ -1,0 +1,9 @@
+package protocol
+
+import erro "github.com/njones/socketio/internal/errors"
+
+const (
+	ErrDecodeBase64Failed erro.StringF = "failed to decode msgpack base64 field:: %w"
+	ErrDecodeFieldFailed  erro.StringF = "failed to decode msgpack field:: %w"
+	ErrEncodeFieldFailed  erro.StringF = "failed to encode msgpack field:: %w"
+)

--- a/protocol/packet.pac.ackid.go
+++ b/protocol/packet.pac.ackid.go
@@ -24,7 +24,7 @@ func (x packetAckID) Read(p []byte) (n int, err error) {
 	n = copy(p, []byte(numStr))
 
 	if n < len(numStr) {
-		return n, ErrOnReadSoBuffer.BufferF("AckID", []byte(numStr)[n:], ErrShortRead)
+		return n, ErrReadUseBuffer.BufferF("AckID", []byte(numStr)[n:], ErrShortRead)
 	}
 
 	return n, nil

--- a/protocol/packet.pac.ns.go
+++ b/protocol/packet.pac.ns.go
@@ -23,7 +23,7 @@ func (x packetNS) Read(p []byte) (n int, err error) {
 	}
 
 	if n = copy(p, x); n < len(x) {
-		return n, ErrOnReadSoBuffer.BufferF("namespace", []byte(x)[n:], ErrShortRead)
+		return n, ErrReadUseBuffer.BufferF("namespace", []byte(x)[n:], ErrShortRead)
 	}
 
 	return n, nil

--- a/protocol/packet.pac.stream.go
+++ b/protocol/packet.pac.stream.go
@@ -30,7 +30,7 @@ func (x binaryStreamIn) Read(p []byte) (n int, err error) {
 	n = copy(p, numStr)
 
 	if n < len(numStr) {
-		return n, ErrOnReadSoBuffer.BufferF("binary stream", []byte(numStr)[n:], ErrShortRead)
+		return n, ErrReadUseBuffer.BufferF("binary stream", []byte(numStr)[n:], ErrShortRead)
 	}
 
 	return n, nil
@@ -55,7 +55,7 @@ func (x *binaryStreamIn) Write(p []byte) (n int, err error) {
 		case '-':
 			k, err := strconv.ParseInt(string(data), 10, 64)
 			if err != nil {
-				err = ErrBadParse.F("incoming binary stream", err)
+				err = ErrParseIntFailed.F("incoming binary stream", err)
 			}
 			*x = make([]func(io.Reader) error, k)
 			return n, err
@@ -70,7 +70,7 @@ func (x *binaryStreamIn) Write(p []byte) (n int, err error) {
 
 	num, err := strconv.ParseInt(string(data), 10, 64)
 	if err != nil {
-		err = ErrBadParse.F("incoming binary stream", err)
+		err = ErrParseIntFailed.F("incoming binary stream", err)
 		return n, err
 	}
 

--- a/protocol/packet.v3.go
+++ b/protocol/packet.v3.go
@@ -172,7 +172,7 @@ func packetDataArrayUnmarshalV3(incoming *binaryStreamIn) func([]byte, interface
 	return func(data_ []byte, vw interface{}) error {
 		err := json.Unmarshal(data_, vw)
 		if err != nil {
-			return ErrBadInitialFieldUnmarshal.F(err)
+			return ErrUnmarshalInitialFieldFailed.F(err)
 		}
 
 		// replace your binary data...
@@ -212,7 +212,7 @@ func packetDataObjectUnmarshalV3(incoming *binaryStreamIn) func([]byte, interfac
 	return func(data_ []byte, vw interface{}) error {
 		err := json.Unmarshal(data_, vw)
 		if err != nil {
-			return ErrBadInitialFieldUnmarshal.F(err)
+			return ErrUnmarshalInitialFieldFailed.F(err)
 		}
 
 		// replace your binary data...

--- a/protocol/scratch.go
+++ b/protocol/scratch.go
@@ -304,7 +304,7 @@ func withPacketData(v interface{}) packetData {
 	case error:
 		return readWriteErr{val}
 	default:
-		return readWriteErr{ErrInvalidPacketType.F(val)}
+		return readWriteErr{ErrUnexpectedPacketType.F(val)}
 	}
 }
 

--- a/serialize/error.go
+++ b/serialize/error.go
@@ -5,5 +5,6 @@ import (
 )
 
 const (
-	ErrSerializableBinary erro.String = "can not serialize the object, use Read instead"
+	ErrUnsupportedUseRead erro.String = "Serialize() method unsupported, use the Read() method instead"
+	ErrUnsupported        erro.String = "method: unsupported"
 )

--- a/serialize/serialize.go
+++ b/serialize/serialize.go
@@ -68,8 +68,8 @@ type (
 
 func Any(v interface{}) *_any                      { return &_any{v} }
 func (x *_any) String() (str string)               { str, _ = x.Serialize(); return }
-func (x *_any) Serialize() (str string, err error) { return "", ErrSerializableBinary }
-func (x *_any) Unserialize(str string) (err error) { return ErrSerializableBinary }
+func (x *_any) Serialize() (str string, err error) { return "", ErrUnsupported }
+func (x *_any) Unserialize(str string) (err error) { return ErrUnsupported }
 func (x *_any) Interface() (v interface{})         { return x.a }
 func (x _anyWrap) Unserialize(string) error        { return nil }
 func (x _anyWrap) String() string                  { return "" }
@@ -82,8 +82,8 @@ type (
 func Binary(v io.Reader) *_binary                     { return &_binary{v} }
 func (x *_binary) Read(p []byte) (n int, err error)   { return x.r.Read(p) }
 func (x *_binary) String() (str string)               { str, _ = x.Serialize(); return }
-func (x *_binary) Serialize() (str string, err error) { return "", ErrSerializableBinary }
-func (x *_binary) Unserialize(str string) (err error) { return ErrSerializableBinary }
+func (x *_binary) Serialize() (str string, err error) { return "", ErrUnsupportedUseRead }
+func (x *_binary) Unserialize(str string) (err error) { return ErrUnsupported }
 func (x *_binary) Interface() (v interface{})         { return x.r }
 func (x _binaryWrap) Unserialize(string) error        { return nil }
 func (x _binaryWrap) String() string                  { return "" }

--- a/server.v1.go
+++ b/server.v1.go
@@ -127,10 +127,10 @@ func (v1 *ServerV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		case
 			errors.Is(err, eio.HTTPStatusError400),
-			errors.Is(err, eio.ErrNoSessionID),
-			errors.Is(err, eio.ErrNoEIOVersion),
-			errors.Is(err, eio.ErrNoTransport),
-			errors.Is(err, eio.ErrBadRequestMethod):
+			errors.Is(err, eio.ErrUnknownSessionID),
+			errors.Is(err, eio.ErrUnknownEIOVersion),
+			errors.Is(err, eio.ErrUnknownTransport),
+			errors.Is(err, eio.ErrRequestHTTPMethod):
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}

--- a/server.v1.runback.go
+++ b/server.v1.runback.go
@@ -60,7 +60,7 @@ func doV1(v1 *ServerV1, socketID SocketID, socket siot.Socket, req *Request) err
 		}
 	case siop.DisconnectPacket.Byte():
 		if err := v1.doDisconnectPacket(socketID, socket, req); err != nil {
-			if errors.Is(err, ErrBadOnDisconnectSocket) {
+			if errors.Is(err, ErrOnDisconnectSocket) {
 				return nil
 			}
 			v1.tr().Send(socketID, serviceError(err), siop.WithType(siop.ErrorPacket.Byte()))
@@ -78,7 +78,7 @@ func doV1(v1 *ServerV1, socketID SocketID, socket siot.Socket, req *Request) err
 			return e
 		}
 	default:
-		err := ErrInvalidPacketType.F("v1", socket)
+		err := ErrUnexpectedPacketType.F(socket).KV(ver, "v1")
 		v1.tr().Send(socketID, serviceError(err), siop.WithType(siop.ErrorPacket.Byte()))
 	}
 	return nil
@@ -96,7 +96,7 @@ func doConnectPacket(v1 *ServerV1) func(SocketID, siot.Socket, *Request) error {
 		if fn, ok := v1.onConnect[socket.Namespace]; ok {
 			return fn(&SocketV1{inSocketV1: v1.inSocketV1.clone(), req: req, Connected: true})
 		}
-		return ErrBadOnConnectSocket
+		return ErrOnConnectSocket
 	}
 }
 
@@ -111,7 +111,7 @@ func doDisconnectPacket(v1 *ServerV1) func(SocketID, siot.Socket, *Request) erro
 			v1.tr().Leave(socket.Namespace, socketID, socketIDPrefix+socketID.String())
 			return fn.Callback("client namespace disconnect")
 		}
-		return ErrBadOnDisconnectSocket
+		return ErrOnDisconnectSocket
 	}
 }
 
@@ -125,7 +125,7 @@ func doEventPacket(v1 *ServerV1) func(SocketID, siot.Socket) error {
 		case []interface{}:
 			event, ok := data[0].(string)
 			if !ok {
-				return ErrBadEventName
+				return ErrUnknownEventName
 			}
 			if socket.Type != siop.DisconnectPacket.Byte() {
 				data = data[1:]
@@ -162,7 +162,7 @@ func doEventPacket(v1 *ServerV1) func(SocketID, siot.Socket) error {
 				return fn.Callback(stoi(data)...)
 			}
 		}
-		return ErrInvalidData.F(fmt.Sprintf("type %s", socket.Data)).KV("do", "eventPacket")
+		return ErrUnexpectedData.F(socket.Data).KV("do", "eventPacket")
 	}
 }
 
@@ -180,7 +180,7 @@ func doAckPacket(v1 *ServerV1) func(SocketID, siot.Socket) error {
 				err = fn.Callback(stoi(data)...)
 			}
 		default:
-			return ErrInvalidData.F(fmt.Sprintf("type %s", data)).KV("do", "ackPacket")
+			return ErrUnexpectedData.F(data).KV("do", "ackPacket")
 		}
 		return err
 	}

--- a/server.v1.socket.go
+++ b/server.v1.socket.go
@@ -133,7 +133,7 @@ func (v1 inSocketV1) OnDisconnect(callback func(string)) {
 
 func (v1 inSocketV1) On(event Event, callback eventCallback) {
 	if _, ok := v1.protectedEventName[event]; ok {
-		v1.on(event, call.ErrorWrap(func() error { return ErrInvalidEventName.F(event) }))
+		v1.on(event, call.ErrorWrap(func() error { return ErrUnsupportedEventName.F(event) }))
 		return
 	}
 	v1.on(event, callback)
@@ -208,7 +208,7 @@ func (v1 inSocketV1) Emit(event Event, data ...Data) error {
 	for _, toRoom := range v1.to {
 		rooms, err := transport.Sockets(v1.nsp()).FromRoom(toRoom)
 		if err != nil {
-			return ErrFromRoom.F(err)
+			return ErrFromRoomFailed.F(err)
 		}
 
 		for _, id := range rooms {

--- a/server.v2.runback.go
+++ b/server.v2.runback.go
@@ -20,7 +20,7 @@ func doConnectPacketV2(v2 *ServerV2) func(SocketID, siot.Socket, *Request) error
 		if fn, ok := v2.onConnect[socket.Namespace]; ok {
 			return fn(&SocketV2{inSocketV2: v2.inSocketV2.clone(), req: req})
 		}
-		return ErrBadOnConnectSocket
+		return ErrOnConnectSocket
 	}
 }
 
@@ -35,7 +35,7 @@ func doBinaryEventPacket(v2 *ServerV2) func(SocketID, siot.Socket) error {
 		case []interface{}:
 			event, ok := data[0].(string)
 			if !ok {
-				return ErrOnBinaryEvent.F(data)
+				return ErrUnknownBinaryEventName.F(data)
 			}
 			if fn, ok := v1.events[socket.Namespace][event][socketID]; ok {
 				if socket.AckID > 0 {
@@ -61,7 +61,7 @@ func doBinaryEventPacket(v2 *ServerV2) func(SocketID, siot.Socket) error {
 				err = fn.Callback(stoi(data[1:])...)
 			}
 		default:
-			return ErrInvalidPacketTypeExpected.F(socket.Data)
+			return ErrUnexpectedBinaryData.F(socket.Data)
 		}
 		return err
 	}

--- a/server.v3.runback.go
+++ b/server.v3.runback.go
@@ -45,7 +45,7 @@ func doBinaryAckPacket(v1 *ServerV1) func(SocketID, siot.Socket) error {
 				err = fn.Callback(stoi(data[1:])...)
 			}
 		default:
-			return ErrInvalidPacketTypeExpected.F(socket.Data)
+			return ErrUnexpectedBinaryData.F(socket.Data)
 		}
 		return err
 	}

--- a/server.v4.socket.go
+++ b/server.v4.socket.go
@@ -123,7 +123,7 @@ func (v4 inSocketV4) Emit(event Event, data ...Data) error {
 	for _, exceptRoom := range v4.except {
 		rooms, err := transport.Sockets(v1.nsp()).FromRoom(exceptRoom)
 		if err != nil {
-			ErrFromRoom.F(err)
+			ErrFromRoomFailed.F(err)
 		}
 		for _, id := range rooms {
 			uniqueID[id] = struct{}{}
@@ -132,7 +132,7 @@ func (v4 inSocketV4) Emit(event Event, data ...Data) error {
 	for _, toRoom := range v1.to {
 		ids, err := transport.Sockets(v1.nsp()).FromRoom(toRoom)
 		if err != nil {
-			ErrFromRoom.F(err)
+			ErrFromRoomFailed.F(err)
 		}
 
 		for _, id := range ids {

--- a/utility.go
+++ b/utility.go
@@ -35,7 +35,7 @@ func scrub(useBinary bool, event Event, data []seri.Serializable) (hasBinary boo
 			}
 			rtn[i+1], err = v.Serialize()
 			if err != nil {
-				return hasBinary, nil, cb, ErrBadScrub.F(err)
+				return hasBinary, nil, cb, ErrScrubFailed.F(err)
 			}
 		}
 		return hasBinary, rtn, nil, nil


### PR DESCRIPTION
**This commit:**
  Removes vestigial errors from refactored packages
  Standardizes error names, so they reflect what the error text will be
  Standardizes error text, so it's clear and actionable
  Separates formatted and non formatted error strings, to make it easier for compile time checks and linters
  Pulls out the MessagePack errors so that build flags can be used to remove them like the other MessagePack items
  Pulls out versioning from error text, and places it in the KV structured errors part