### PR TITLE
A lightweight errors refactor

### DIFF
--- a/callback/error.go
+++ b/callback/error.go
@@ -10,6 +10,6 @@ const (
 	ErrUnexpectedDataInParams   erro.StringF = "expected %d callback input parameters, found %d"
 	ErrUnexpectedFuncInParams   erro.StringF = "expected %d wrap.Parameter values, found %d"
 	ErrUnexpectedSingleOutParam erro.StringF = "expected a single error return parameter, found %d return parameters"
-	ErrUnknownPanic             erro.String  = "unknown panic"
 	ErrInterfaceNotFound        erro.String  = "interface not found for serialize"
+	ErrUnknownPanic             erro.State   = "unknown panic"
 )

--- a/engineio/protocol/error.go
+++ b/engineio/protocol/error.go
@@ -2,13 +2,11 @@ package protocol
 
 import erro "github.com/njones/socketio/internal/errors"
 
-func kv(v ...interface{}) erro.Struct { return erro.KV(v...) }
-
 const ver = "version"
 
 const (
-	ErrUnexpectedPacketType  erro.StringF = "unexpected packet type %s"
-	ErrUnexpectedPacketData  erro.StringF = "unexpected packet data %s"
+	ErrUnexpectedPacketType  erro.StringF = "unexpected packet type %T"
+	ErrUnexpectedPacketData  erro.StringF = "unexpected packet data %T"
 	ErrUnexpectedHandshake   erro.StringF = "expected %s, found %T"
 	ErrDecodeHandshakeFailed erro.StringF = "failed to decode handshake:: %w"
 	ErrEncodeHandshakeFailed erro.StringF = "failed to encode handshake:: %w"
@@ -18,3 +16,5 @@ const (
 	ErrEncodePayloadFailed   erro.StringF = "failed to encode payload:: %w"
 	EOR                      erro.StringF = "End Of Record: %w"
 )
+
+func kv(v ...interface{}) erro.Struct { return erro.KV(v...) }

--- a/engineio/protocol/packet.v2.go
+++ b/engineio/protocol/packet.v2.go
@@ -99,12 +99,12 @@ func (enc *PacketEncoderV2) Encode(packet PacketV2) (err error) {
 			enc.write.Bytes(packet.T.Bytes()).OnErrF(ErrEncodePacketFailed, enc.write, kv(ver, "v2"))
 			enc.write.Encode(data).OnErrF(ErrEncodePacketFailed, enc.write, kv(ver, "v2"))
 		default:
-			return ErrUnexpectedPacketData.F(fmt.Sprintf("unexpected data type of: %T", data))
+			return ErrUnexpectedPacketData.F(data)
 		}
 	case ClosePacket, UpgradePacket, NoopPacket:
 		enc.write.Bytes(packet.T.Bytes()).OnErrF(ErrEncodePacketFailed, enc.write, kv(ver, "v2"))
 	default:
-		return ErrUnexpectedPacketType.F(fmt.Sprintf("unexpected packet type of: %s", packet.T))
+		return ErrUnexpectedPacketType.F(packet.T)
 	}
 
 	return enc.write.Err()

--- a/engineio/server.v2.go
+++ b/engineio/server.v2.go
@@ -113,7 +113,7 @@ func (v2 *serverV2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 HandleError:
 	if err != nil {
 		switch {
-		case errors.Is(err, ErrRequestHTTPMethod):
+		case errors.Is(err, ErrInvalidRequestHTTPMethod):
 			return
 		}
 		return
@@ -122,7 +122,7 @@ HandleError:
 
 func (v2 *serverV2) ServeTransport(w http.ResponseWriter, r *http.Request) (eiot.Transporter, error) {
 	if v2.path == nil || !strings.HasPrefix(r.URL.Path, *v2.path) {
-		return nil, ErrURIPath
+		return nil, ErrInvalidURIPath
 	}
 
 	sessionID := sessionIDFrom(r)
@@ -136,7 +136,7 @@ func (v2 *serverV2) ServeTransport(w http.ResponseWriter, r *http.Request) (eiot
 		}
 		fallthrough
 	default:
-		return nil, ErrRequestHTTPMethod
+		return nil, ErrInvalidRequestHTTPMethod
 	}
 
 	eioVersion := eioVersionFrom(r)
@@ -258,7 +258,7 @@ func (v2 *serverV2) doUpgrade(transport eiot.Transporter, err error) func(http.R
 					return transport, isUpgrade, func() error { return v2.sessions.Set(transport) }, nil
 				}
 			}
-			return nil, false, nil, ErrBadUpgrade
+			return nil, false, nil, ErrTransportUpgradeFailed
 		}
 		return transport, isUpgrade, nil, err
 	}

--- a/engineio/transport/error.go
+++ b/engineio/transport/error.go
@@ -6,6 +6,6 @@ const (
 	ErrDecodeFailed        erro.StringF = "failed to decode the %q transport:: %w"
 	ErrEncodeFailed        erro.StringF = "failed to encode the %q transport:: %w"
 	ErrUnimplementedMethod erro.StringF = "unimplemented %s method"
-	ErrCloseSocket         erro.String  = "socket: closed"
-	ErrTimeoutSocket       erro.String  = "socket: timeout"
+	ErrCloseSocket         erro.State   = "socket: closed"
+	ErrTimeoutSocket       erro.State   = "socket: timeout"
 )

--- a/error.go
+++ b/error.go
@@ -16,6 +16,6 @@ const (
 	ErrUnexpectedBinaryData   erro.StringF = "expected an []interface{} (binary array) or []string, found %T"
 	ErrUnexpectedPacketType   erro.StringF = "unexpected %T"
 	ErrNamespaceNotFound      erro.StringF = "namespace %q not found"
-	ErrOnConnectSocket        erro.String  = "socket: invalid onconnect"
-	ErrOnDisconnectSocket     erro.String  = "socket: invalid ondisconnect"
+	ErrOnConnectSocket        erro.State   = "socket: invalid onconnect"
+	ErrOnDisconnectSocket     erro.State   = "socket: invalid ondisconnect"
 )

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -25,18 +25,32 @@ import (
 	"strings"
 )
 
+type StatusError string
+
+func (e StatusError) Error() string { return string(e) }
+
+const HTTPStatusErrorLen = len(HTTPStatusError400)
+const HTTPStatusError400 StatusError = "|400| "
+
 func KV(kv ...interface{}) Struct { return Struct{kv: kv} }
 
 type (
+	State   string
 	StringF string
-	String  string
-	Struct  struct {
+
+	String string
+	Struct struct {
 		e, rr error
 		wrap  []error
 		f     [][]interface{}
 		kv    []interface{}
 	}
 )
+
+func (e State) Error() string { return string(e) }
+func (e State) KV(kv ...interface{}) Struct {
+	return Struct{e: e, rr: e, kv: kv}
+}
 
 func (e StringF) Error() string { return string(e) }
 func (e StringF) F(v ...interface{}) Struct {

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -21,9 +21,9 @@ const (
 	ErrUnexpectedJSONEnd           erro.String  = "unexpected JSON end"
 	ErrBinaryDataUnsupported       erro.String  = "binary data unsupported in this version"
 	ErrReadUseBuffer               errsPacket   = "%s: read buffer"
-	ErrShortRead                   erro.String  = "read: short"
-	ErrShortWrite                  erro.String  = "write: short"
-	ErrEmptyDataArray              erro.String  = "data array: empty"
+	ErrShortRead                   erro.State   = "read: short"
+	ErrShortWrite                  erro.State   = "write: short"
+	ErrEmptyDataArray              erro.State   = "data array: empty"
 )
 
 // errsPacket is an error type that can send back PacketError errors.

--- a/serialize/error.go
+++ b/serialize/error.go
@@ -6,5 +6,5 @@ import (
 
 const (
 	ErrUnsupportedUseRead erro.String = "Serialize() method unsupported, use the Read() method instead"
-	ErrUnsupported        erro.String = "method: unsupported"
+	ErrUnsupported        erro.State  = "method: unsupported"
 )

--- a/server.v1.go
+++ b/server.v1.go
@@ -9,7 +9,7 @@ import (
 
 	nmem "github.com/njones/socketio/adaptor/transport/memory"
 	eio "github.com/njones/socketio/engineio"
-	eiot "github.com/njones/socketio/engineio/transport"
+	erro "github.com/njones/socketio/internal/errors"
 	siop "github.com/njones/socketio/protocol"
 	siot "github.com/njones/socketio/transport"
 )
@@ -118,19 +118,12 @@ func (v1 *ServerV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ctx = v1.ctx
 	}
 
+	var eState erro.State
 	if err := v1.serveHTTP(w, r.WithContext(ctx)); err != nil {
 		switch {
-		case
-			errors.Is(err, eiot.ErrTimeoutSocket),
-			errors.Is(err, eiot.ErrCloseSocket),
-			errors.Is(err, eio.EOH):
+		case errors.As(err, &eState):
 			return
-		case
-			errors.Is(err, eio.HTTPStatusError400),
-			errors.Is(err, eio.ErrUnknownSessionID),
-			errors.Is(err, eio.ErrUnknownEIOVersion),
-			errors.Is(err, eio.ErrUnknownTransport),
-			errors.Is(err, eio.ErrRequestHTTPMethod):
+		case errors.Is(err, erro.HTTPStatusError400):
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
* Added a State type for errors, so that they can be managed as a type through the socketio package HTTP handler 
* Refactored the HTTP 400 errors so they don't appear so complicated, and can be managed as a prefix through the socketio package HTTP handler
*  Moved a few functions and error strings around, to increase code readability