### PR TITLE
Update error handling for errors.Struct Is method

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -119,6 +119,9 @@ func (e Struct) Is(target error) bool {
 	if eStr, ok := target.(String); ok {
 		return e.e.Error() == eStr.Error()
 	}
+	if eStr, ok := target.(StringF); ok {
+		return e.e.Error() == eStr.Error()
+	}
 	for _, werr := range e.wrap {
 		if errors.Is(werr, target) {
 			return true

--- a/server.v4.runback.go
+++ b/server.v4.runback.go
@@ -59,13 +59,13 @@ func doV4(v4 *ServerV4, socketID SocketID, socket siot.Socket, req *Request) err
 
 	switch socket.Type {
 	case siop.ConnectPacket.Byte():
-		unlock := v4.prev.prev.prev.r()
+		unlock := v1.r()
 		tr := v4.tr()
 		unlock()
 
 		if err := v1.doConnectPacket(socketID, socket, req); err != nil {
 			if errors.Is(err, ErrNamespaceNotFound) {
-				tr.Send(socketID, serviceError(fmt.Errorf("%snvalid namespace", "I")), siop.WithNamespace(socket.Namespace), siop.WithType(byte(siop.ConnectErrorPacket)))
+				tr.Send(socketID, serviceError(fmt.Errorf("%valid namespace", "Inv")), siop.WithNamespace(socket.Namespace), siop.WithType(byte(siop.ConnectErrorPacket)))
 				return nil
 			}
 			tr.Send(socketID, serviceError(err), siop.WithType(byte(siop.ConnectErrorPacket)))


### PR DESCRIPTION
Added StringF Is method error matching, to the internal errors.Struct object This fixes an issue in `server.v4.runback.go` where the wrong error message was being sent back, because the Is method was broken for StringF errors.

Uses "%valid", "Inv" to produce "Invalid" with a capital letter for the error message, which is marked as incorrect by the go linter. The "%v" with "alid" produces a valid word while providing a valid formatting option to provide a string.