### PR TITLE
Fix the namespace auto-connect in SocketIO v2 & v3

### DIFF
--- a/engineio/transport/transport.go
+++ b/engineio/transport/transport.go
@@ -39,6 +39,8 @@ type Transporter interface {
 
 type StartWriteBuffer func() bool
 
+func (StartWriteBuffer) Len() int { return 0 }
+
 type Transport struct {
 	id    SessionID
 	name  Name

--- a/engineio/transport/transport.polling.go
+++ b/engineio/transport/transport.polling.go
@@ -90,6 +90,7 @@ Write:
 				}
 				break Write
 			case StartWriteBuffer:
+				packets = append(packets, packet)
 				if v() {
 					buffer.use = true
 					buffer.idx = len(packets)

--- a/server.v1.runback.go
+++ b/server.v1.runback.go
@@ -19,16 +19,14 @@ func autoConnect(v1 *ServerV1, newPacket siop.NewPacket) func(transport eiot.Tra
 			return
 		}
 
+		sioPacket := newPacket().WithType(siop.ConnectPacket.Byte())
+		eioPacket := eiop.Packet{T: eiop.MessagePacket, D: sioPacket}
+		transport.Send(eioPacket)
+		transport.Send(eiop.Packet{T: eiop.NoopPacket, D: eiot.StartWriteBuffer(func() bool { return true })})
+
 		socket := siot.Socket{
 			Type:      siop.ConnectPacket.Byte(),
 			Namespace: "/",
-		}
-
-		if transport.Name() == eiot.Polling {
-			sioPacket := newPacket().WithType(siop.ConnectPacket.Byte())
-			eioPacket := eiop.Packet{T: eiop.MessagePacket, D: sioPacket}
-			transport.Send(eioPacket)
-			transport.Send(eiop.Packet{T: eiop.NoopPacket, D: eiot.StartWriteBuffer(func() bool { return true })})
 		}
 
 		if err := v1.doConnectPacket(socketID, socket, sioRequest(r)); err != nil {


### PR DESCRIPTION
Removed the polling only auto-connect for namespaces (this is why it wasn't working for the websocket transport). Also fixed a small issue with version3 Payload encoding, where the packet length was not being reported for NOOP packets.

[fixes #60]
[fixes #61]