### PR TITLE
Update tests to allow for auto-connect namespaces

### DIFF
--- a/server.v1_test.go
+++ b/server.v1_test.go
@@ -235,9 +235,9 @@ func SendingToTheClientV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["hello","can you hear me?",1,2,"abc"]`},
-				{`42["hello","can you hear me?",1,2,"abc"]`},
-				{`42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -269,9 +269,9 @@ func SendingToAllClientsExceptTheSenderV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["broadcast","Hello friends!"]`},
-				{`42["broadcast","Hello friends!"]`},
-				nil,
+				{`40`, `6`, `42["broadcast","Hello friends!"]`},
+				{`40`, `6`, `42["broadcast","Hello friends!"]`},
+				{`40`, `6`},
 			},
 		}
 		count = len(want["grab1"])
@@ -305,11 +305,11 @@ func SendingToAllClientsInGameRoomExceptSenderV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["nice game","let's play a game"]`},
-				nil,
-				{`42["nice game","let's play a game"]`},
-				nil,
-				nil, // sender...
+				{`40`, `6`, `42["nice game","let's play a game"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game"]`},
+				{`40`, `6`},
+				{`40`, `6`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -346,19 +346,19 @@ func SendingToAllClientsInGame1AndOrGame2RoomExceptSenderV1(*testing.T) []testDa
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				nil, // sender...
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -398,11 +398,11 @@ func SendingToAllClientsInGameRoomIncludingSenderV1(*testing.T) []testDataOptFun
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["big-announcement","the game will start soon"]`},
-				nil,
-				{`42["big-announcement","the game will start soon"]`},
-				nil,
-				{`42["big-announcement","the game will start soon"]`},
+				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -446,11 +446,11 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV1(*testing.T) []te
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				nil,
-				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				nil,
-				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`}, // 42/myNamespace,["bigger-announcement","the tournament will start soon"]
+				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`}, // 42/myNamespace,["bigger-announcement","the tournament will start soon"]
 			},
 		}
 		count = len(want["send1"])
@@ -503,11 +503,11 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV1(*testing.T) [
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`42/myNamespace,["event","message"]`},
-				nil,
-				nil,
-				nil,
-				{`42/myNamespace,["event","message"]`},
+				{`40`, `6`, `42/myNamespace,["event","message"]`},
+				{`40`, `6`},
+				{`40`, `6`},
+				{`40`, `6`},
+				{`40`, `6`, `42/myNamespace,["event","message"]`},
 			},
 		}
 		count = len(want["send1"])
@@ -560,9 +560,9 @@ func SendingToIndividualSocketIDPrivateMessageV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["hey","I just met you #1"]`},
-				{`42["hey","I just met you #2"]`},
-				{`42["hey","I just met you #0"]`},
+				{`40`, `6`, `42["hey","I just met you #1"]`},
+				{`40`, `6`, `42["hey","I just met you #2"]`},
+				{`40`, `6`, `42["hey","I just met you #0"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -604,7 +604,7 @@ func SendingWithAcknowledgementV1(t *testing.T) []testDataOptFunc {
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
-			"grab1": {{`421["question","do you think so?"]`}},
+			"grab1": {{`40`, `6`, `421["question","do you think so?"]`}},
 			"send2": {{`431["answer",42]`}},
 		}
 		count = len(want["grab1"])
@@ -652,11 +652,11 @@ func SendingToAllConnectedClientsV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -699,11 +699,11 @@ func OnEventV1(t *testing.T) []testDataOptFunc {
 				{`41`}, nil, nil, nil, nil,
 			},
 			"grab2": {
-				{`42["say goodbye","disconnecting..."]`},
-				nil,
-				{`42["say goodbye","disconnecting..."]`},
-				nil,
-				{`42["say goodbye","disconnecting..."]`},
+				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
 			},
 		}
 		count = len(want["send1"])
@@ -759,7 +759,7 @@ func RejectTheClientV1(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"connect_query": {{`access=true`}, {`access=false`}},
-			"grab1":         {{`42["hello",1]`}, {`44{"message":"not authorized"}`}},
+			"grab1":         {{`40`, `6`, `42["hello",1]`}, {`40`, `6`, `44{"message":"not authorized"}`}},
 		}
 		count = len(want["connect_query"])
 		cnt   = int64(0)

--- a/server.v2_test.go
+++ b/server.v2_test.go
@@ -158,9 +158,9 @@ func SendingToTheClientV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["hello","can you hear me?",1,2,"abc"]`},
-				{`42["hello","can you hear me?",1,2,"abc"]`},
-				{`42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -194,9 +194,9 @@ func SendingToAllClientsExceptTheSenderV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["broadcast","Hello friends!"]`},
-				{`42["broadcast","Hello friends!"]`},
-				nil,
+				{`40`, `6`, `42["broadcast","Hello friends!"]`},
+				{`40`, `6`, `42["broadcast","Hello friends!"]`},
+				{`40`, `6`},
 			},
 		}
 		count = len(want["grab1"])
@@ -232,11 +232,11 @@ func SendingToAllClientsInGameRoomExceptSenderV2(t *testing.T) []testDataOptFunc
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["nice game","let's play a game"]`},
-				nil,
-				{`42["nice game","let's play a game"]`},
-				nil,
-				nil, // sender...
+				{`40`, `6`, `42["nice game","let's play a game"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game"]`},
+				{`40`, `6`},
+				{`40`, `6`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -275,19 +275,19 @@ func SendingToAllClientsInGame1AndOrGame2RoomExceptSenderV2(t *testing.T) []test
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				{`42["nice game","let's play a game (too)"]`},
-				nil,
-				nil, // sender...
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `6`},
+				{`40`, `6`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -329,11 +329,11 @@ func SendingToAllClientsInGameRoomIncludingSenderV2(t *testing.T) []testDataOptF
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["big-announcement","the game will start soon"]`},
-				nil,
-				{`42["big-announcement","the game will start soon"]`},
-				nil,
-				{`42["big-announcement","the game will start soon"]`},
+				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -379,11 +379,11 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV2(t *testing.T) []
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				nil,
-				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				nil,
-				{`42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`, `6`},
+				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
 			},
 		}
 		count = len(want["send1"])
@@ -438,11 +438,11 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV2(t *testing.T)
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`42/myNamespace,["event","message"]`},
-				nil,
-				nil,
-				nil,
-				{`42/myNamespace,["event","message"]`},
+				{`40`, `6`, `42/myNamespace,["event","message"]`},
+				{`40`, `6`},
+				{`40`, `6`},
+				{`40`, `6`},
+				{`40`, `6`, `42/myNamespace,["event","message"]`},
 			},
 		}
 		count = len(want["send1"])
@@ -497,9 +497,9 @@ func SendingToIndividualSocketIDPrivateMessageV2(t *testing.T) []testDataOptFunc
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["hey","I just met you #1"]`},
-				{`42["hey","I just met you #2"]`},
-				{`42["hey","I just met you #0"]`},
+				{`40`, `6`, `42["hey","I just met you #1"]`},
+				{`40`, `6`, `42["hey","I just met you #2"]`},
+				{`40`, `6`, `42["hey","I just met you #0"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -542,7 +542,7 @@ func SendingWithAcknowledgementV2(t *testing.T) []testDataOptFunc {
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
-			"grab1": {{`421["question","do you think so?"]`}},
+			"grab1": {{`40`, `6`, `421["question","do you think so?"]`}},
 			"send2": {{`431["answer",42]`}},
 		}
 		count = len(want["grab1"])
@@ -592,11 +592,11 @@ func SendingToAllConnectedClientsV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
-				{`42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -642,11 +642,11 @@ func OnEventV2(t *testing.T) []testDataOptFunc {
 				{`41`}, nil, nil, nil, nil,
 			},
 			"grab2": {
-				{`42["say goodbye","disconnecting..."]`},
-				nil,
-				{`42["say goodbye","disconnecting..."]`},
-				nil,
-				{`42["say goodbye","disconnecting..."]`},
+				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
+				{`40`, `6`},
+				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
 			},
 		}
 		count = len(want["send1"])
@@ -704,7 +704,7 @@ func RejectTheClientV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"connect_query": {{`access=true`}, {`access=false`}},
-			"grab1":         {{`42["hello",1]`}, {`44{"message":"not authorized"}`}},
+			"grab1":         {{`40`, `6`, `42["hello",1]`}, {`40`, `6`, `44{"message":"not authorized"}`}},
 		}
 		count = len(want["connect_query"])
 		cnt   = int64(0)

--- a/server_test.go
+++ b/server_test.go
@@ -308,6 +308,8 @@ type v1PollingClient struct {
 	base   string
 	buffer *bytes.Buffer
 	client *http.Client
+
+	connect_buf map[string][][]byte
 }
 
 func (c *v1PollingClient) parse(body []byte) (rtn [][]byte) {
@@ -347,6 +349,11 @@ func (c *v1PollingClient) connect(queryStr ...[]string) {
 
 	c.eioSessionID, _ = m["sid"].(string)
 	assert.NotEmpty(c.t, c.eioSessionID)
+
+	if c.connect_buf == nil {
+		c.connect_buf = make(map[string][][]byte)
+	}
+	c.connect_buf[c.eioSessionID] = have[1:]
 }
 func (c *v1PollingClient) send(body io.Reader) {
 	c.t.Helper()
@@ -359,6 +366,13 @@ func (c *v1PollingClient) send(body io.Reader) {
 }
 func (c *v1PollingClient) grab() (rtn []string) {
 	c.t.Helper()
+
+	if len(c.connect_buf[c.eioSessionID]) > 0 {
+		for i := range c.connect_buf[c.eioSessionID] {
+			rtn = append(rtn, string(c.connect_buf[c.eioSessionID][i]))
+		}
+		delete(c.connect_buf, c.eioSessionID)
+	}
 
 	URL := fmt.Sprintf("%s/socket.io/?", c.base) + c.d.paramVersion() + c.d.paramTransport() + c.d.paramSID(c.eioSessionID).grab() + c.d.paramTimestamp()
 	have := c.get(URL)


### PR DESCRIPTION
The tests before were suppressing polling auto-connect messages. Those are now being captured, and the tests have been updated to account for the extra messages.