### PR TITLE
Fix the SocketIO connect protocol

### DIFF
--- a/engineio/protocol/packet.v2_test.go
+++ b/engineio/protocol/packet.v2_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestPacketV2(t *testing.T) {
-	var opts = []func(*testing.T) bool{}
+	var opts = []func(*testing.T){}
 
 	type (
 		testFn          func(*testing.T)
@@ -28,9 +28,7 @@ func TestPacketV2(t *testing.T) {
 		"Decode": func(output PacketV2, input string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()
@@ -45,9 +43,7 @@ func TestPacketV2(t *testing.T) {
 		"Encode": func(input PacketV2, output string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()
@@ -62,9 +58,7 @@ func TestPacketV2(t *testing.T) {
 		"ReadPacket": func(output PacketV2, input string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()
@@ -80,9 +74,7 @@ func TestPacketV2(t *testing.T) {
 		"WritePacket": func(input PacketV2, output string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()
@@ -99,9 +91,7 @@ func TestPacketV2(t *testing.T) {
 		"Short Decode": func(output PacketV2, input string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()
@@ -117,9 +107,7 @@ func TestPacketV2(t *testing.T) {
 		"Short Encode": func(input PacketV2, output string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()
@@ -135,9 +123,7 @@ func TestPacketV2(t *testing.T) {
 		"Short ReadPacket": func(output PacketV2, input string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()
@@ -154,9 +140,7 @@ func TestPacketV2(t *testing.T) {
 		"Short WritePacket": func(input PacketV2, output string, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
-					if !opt(t) {
-						return
-					}
+					opt(t)
 				}
 
 				t.Parallel()

--- a/internal/test/runner.go
+++ b/internal/test/runner.go
@@ -52,16 +52,15 @@ func SkipTest(testNames ...string) func(*testing.T) {
 	}
 }
 
-func DoNotTest(testSuffixes ...string) func(*testing.T) bool {
-	return func(t *testing.T) bool {
+func DoNotTest(testSuffixes ...string) func(*testing.T) {
+	return func(t *testing.T) {
 		t.Helper()
 
 		idx := strings.LastIndex(t.Name(), ".")
 		for _, suffix := range testSuffixes {
 			if t.Name() == t.Name()[:idx]+"."+suffix {
-				return false
+				t.SkipNow()
 			}
 		}
-		return true
 	}
 }

--- a/protocol/packet.go
+++ b/protocol/packet.go
@@ -18,7 +18,7 @@ type Packet interface {
 // This is mainly used when creating new socket.io protocol transports.
 type NewPacket func() Packet
 
-// packet represets a basic socket.io packet of data (v0 through v5)
+// packet represents a basic socket.io packet of data (v0 through v5)
 type packet struct {
 	Type      packetType  `json:"type"`
 	Namespace packetNS    `json:"nsp"`
@@ -30,10 +30,14 @@ type packet struct {
 
 func (pac packet) Len() (n int) {
 	n += pac.Type.Len()
-	n += pac.Namespace.Len()
+	m := pac.Namespace.Len()
+	n += m
 	n += pac.AckID.Len()
 	if x, ok := pac.Data.(interface{ Len() int }); ok {
 		n += x.Len()
+	}
+	if m > 0 && n > m+1 {
+		n += 1 // for the extra namespace comma
 	}
 	return n
 }

--- a/protocol/packet.v2_test.go
+++ b/protocol/packet.v2_test.go
@@ -9,20 +9,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func (d testData) rawPacketV2() PacketV2 { return d.rawPacket.(PacketV2) }
+func (d testData) altPacketV2() PacketV2 { return (d.altPacket).(PacketV2) }
+
 func TestPacketV2(t *testing.T) {
 	var opts = []func(*testing.T){}
 
 	type (
 		testFn          func(*testing.T)
-		testParamsInFn  func(PacketV2, []byte, error) testFn
-		testParamsOutFn func(*testing.T) (PacketV2, []byte, error)
+		testParamsInFn  func(...testDataOptFunc) testFn
+		testParamsOutFn func(*testing.T) []testDataOptFunc
 	)
 
 	runWithOptions := map[string]testParamsInFn{
-		"ReadFrom": func(input PacketV2, output []byte, xErr error) testFn {
+		"ReadFrom": func(testDataOpts ...testDataOptFunc) testFn { // func(input PacketV2, output []byte, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
 					opt(t)
+				}
+
+				var d testData
+				for _, testDataOpt := range testDataOpts {
+					testDataOpt(&d)
+				}
+
+				input, output, xErr := d.rawPacketV2(), d.rawBytes, d.err
+				if d.altPacket != nil {
+					input = d.altPacketV2()
 				}
 
 				var have = new(bytes.Buffer)
@@ -33,11 +46,18 @@ func TestPacketV2(t *testing.T) {
 				assert.Equal(t, output, have.Bytes())
 			}
 		},
-		"Write": func(output PacketV2, input []byte, xErr error) testFn {
+		"Write": func(testDataOpts ...testDataOptFunc) testFn { // func(output PacketV2, input []byte, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
 					opt(t)
 				}
+
+				var d testData
+				for _, testDataOpt := range testDataOpts {
+					testDataOpt(&d)
+				}
+
+				input, output, xErr := d.rawBytes, d.rawPacketV2(), d.err
 
 				var have PacketV2
 				n, err := (&have).Write(input)
@@ -58,10 +78,20 @@ func TestPacketV2(t *testing.T) {
 				}
 			}
 		},
-		"WriteTo": func(input PacketV2, output []byte, xErr error) testFn {
+		"WriteTo": func(testDataOpts ...testDataOptFunc) testFn { //func(input PacketV2, output []byte, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
 					opt(t)
+				}
+
+				var d testData
+				for _, testDataOpt := range testDataOpts {
+					testDataOpt(&d)
+				}
+
+				input, output, xErr := d.rawPacketV2(), d.rawBytes, d.err
+				if d.altPacket != nil {
+					input = d.altPacketV2()
 				}
 
 				var have = new(bytes.Buffer)
@@ -75,114 +105,171 @@ func TestPacketV2(t *testing.T) {
 	}
 
 	spec := map[string]testParamsOutFn{
-		"CONNECT": func(*testing.T) (PacketV2, []byte, error) {
+		"CONNECT": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`0`)
 			asPacket := *NewPacketV2().WithNamespace("/").(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"DISCONNECT": func(*testing.T) (PacketV2, []byte, error) {
+		"DISCONNECT": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`1/admin`)
 			asPacket := *NewPacketV2().
 				WithType(DisconnectPacket.Byte()).
 				WithNamespace("/admin").(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"EVENT": func(*testing.T) (PacketV2, []byte, error) {
+		"EVENT": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`2["hello",1]`)
 			asPacket := *NewPacketV2().
 				WithType(EventPacket.Byte()).
 				WithNamespace("/").
 				WithData([]interface{}{"hello", 1.0}).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"EVENT with AckID": func(*testing.T) (PacketV2, []byte, error) {
+		"EVENT with AckID": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`2/admin,456["project:delete",123]`)
 			asPacket := *NewPacketV2().
 				WithType(EventPacket.Byte()).
 				WithNamespace("/admin").
 				WithData([]interface{}{"project:delete", 123.0}).
 				WithAckID(456).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"ACK": func(*testing.T) (PacketV2, []byte, error) {
+		"ACK": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`3/admin,456[]`)
 			asPacket := *NewPacketV2().
 				WithType(AckPacket.Byte()).
 				WithNamespace("/admin").
 				WithData([]interface{}{}).
 				WithAckID(456).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"ERROR": func(*testing.T) (PacketV2, []byte, error) {
+		"ERROR": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`4/admin,"Not authorized"`)
 			asPacket := *NewPacketV2().
 				WithType(ErrorPacket.Byte()).
 				WithNamespace("/admin").
 				WithData(&notAuthorized).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"BINARY EVENT": func(*testing.T) (PacketV2, []byte, error) {
+		"BINARY EVENT": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`51-["hello",{"base64":true,"data":"xAMBAgM="}]`)
 			asPacket := *NewPacketV2().
 				WithType(BinaryEventPacket.Byte()).
 				WithNamespace("/").
 				WithData([]interface{}{"hello", bytes.NewReader([]byte{0x01, 0x02, 0x03})}).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"BINARY EVENT with AckID": func(*testing.T) (PacketV2, []byte, error) {
+		"BINARY EVENT with AckID": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`51-/admin,456["hello",{"base64":true,"data":"xAMBAgM="}]`)
 			asPacket := *NewPacketV2().
 				WithType(BinaryEventPacket.Byte()).
 				WithNamespace("/admin").
 				WithData([]interface{}{"hello", bytes.NewReader([]byte{0x01, 0x02, 0x03})}).
 				WithAckID(456).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
 
 		// extra
-		"CONNECT /admin ns": func(*testing.T) (PacketV2, []byte, error) {
+		"CONNECT /admin ns": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`0/admin`)
 			asPacket := *NewPacketV2().
 				WithNamespace("/admin").(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"CONNECT /admin ns and extra info": func(*testing.T) (PacketV2, []byte, error) {
+		"CONNECT /admin ns and extra info": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`0/admin?token=1234&uid=abcd`)
 			asPacket := *NewPacketV2().
-				WithNamespace("/admin?token=1234&uid=abcd").(*PacketV2)
-			return asPacket, asBytes, nil
+				WithNamespace("/admin").(*PacketV2)
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) {
+					as2Packet := asPacket
+					as2Packet.WithNamespace("/admin?token=1234&uid=abcd")
+					d.altPacket = as2Packet
+				},
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"EVENT with Binary": func(*testing.T) (PacketV2, []byte, error) {
+		"EVENT with Binary": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`21-["name",{"base64":true,"data":"xAtiaW5hcnkgZGF0YQ=="}]`)
 			asPacket := *NewPacketV2().
 				WithType(EventPacket.Byte()).
 				WithNamespace("/").
 				WithData([]interface{}{"name", bytes.NewReader([]byte("binary data"))}).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"ACK with Object": func(*testing.T) (PacketV2, []byte, error) {
+		"ACK with Object": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`3/site,444{"api-mocked.com":"member"}`)
 			asPacket := *NewPacketV2().
 				WithType(AckPacket.Byte()).
 				WithNamespace("/site").
 				WithData(map[string]interface{}{"api-mocked.com": "member"}).
 				WithAckID(444).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"ACK with Object and Binary": func(*testing.T) (PacketV2, []byte, error) {
+		"ACK with Object and Binary": func(*testing.T) []testDataOptFunc {
 			asBytes := []byte(`31-/site,444{"api-mocked.com":{"base64":true,"data":"xAtiaW5hcnkgZGF0YQ=="}}`)
 			asPacket := *NewPacketV2().
 				WithType(AckPacket.Byte()).
 				WithNamespace("/site").
 				WithData(map[string]interface{}{"api-mocked.com": strings.NewReader("binary data")}).
 				WithAckID(444).(*PacketV2)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawBytes = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
 	}
 
 	for name, testParams := range spec {
 		for suffix, run := range runWithOptions {
-			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)...))
 		}
 	}
 }

--- a/protocol/packet.v4_test.go
+++ b/protocol/packet.v4_test.go
@@ -9,20 +9,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func (d testData) rawPacketV4() PacketV4 { return d.rawPacket.(PacketV4) }
+func (d testData) altPacketV4() PacketV4 { return (d.altPacket).(PacketV4) }
+
 func TestPacketV4(t *testing.T) {
 	var opts = []func(*testing.T){}
 
 	type (
 		testFn          func(*testing.T)
-		testParamsInFn  func(PacketV4, [][]byte, error) testFn
-		testParamsOutFn func(*testing.T) (PacketV4, [][]byte, error)
+		testParamsInFn  func(...testDataOptFunc) testFn
+		testParamsOutFn func(*testing.T) []testDataOptFunc
 	)
 
 	runWithOptions := map[string]testParamsInFn{
-		"ReadFrom": func(input PacketV4, output [][]byte, xErr error) testFn {
+		"ReadFrom": func(testDataOpts ...testDataOptFunc) testFn { // func(input PacketV4, output [][]byte, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
 					opt(t)
+				}
+
+				var d testData
+				for _, testDataOpt := range testDataOpts {
+					testDataOpt(&d)
+				}
+
+				input, output, xErr := d.rawPacketV4(), d.rawByteSlice, d.err
+				if d.altPacket != nil {
+					input = d.altPacketV4()
 				}
 
 				var have = new(bytes.Buffer)
@@ -36,39 +49,46 @@ func TestPacketV4(t *testing.T) {
 				for i, next := range output[1:] {
 					have.Reset()
 					input.outgoing.WriteTo(have)
-					assert.Equal(t, next, have.Bytes(), fmt.Sprintf("writeTo #%d", i))
+					assert.Equal(t, next, have.Bytes(), fmt.Sprintf("ReadFrom #%d", i))
 					cont := input.outgoing.Next()
 					assert.Equal(t, i != len(output[1:])-1, cont, fmt.Sprintf("cont #%d", i))
 				}
 			}
 		},
-		"Write": func(input PacketV4, output [][]byte, xErr error) testFn {
+		"Write": func(testDataOpts ...testDataOptFunc) testFn { // func(input PacketV4, output [][]byte, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
 					opt(t)
 				}
 
-				var have PacketV4
-				n, err := (&have).Write(output[0])
+				var d testData
+				for _, testDataOpt := range testDataOpts {
+					testDataOpt(&d)
+				}
 
-				assert.Equal(t, len(output[0]), n, "the data length")
+				input, output, xErr := d.rawByteSlice, d.rawPacketV4(), d.err
+
+				var have PacketV4
+				n, err := (&have).Write(input[0])
+
+				assert.Equal(t, len(input[0]), n, "the data length")
 				assert.ErrorIs(t, err, xErr)
 
 				go func() {
 					for i, next := range have.incoming {
-						err := next(bytes.NewReader(output[i+1]))
+						err := next(bytes.NewReader(input[i+1]))
 						assert.NoError(t, err)
 					}
 				}()
 
-				assert.Equal(t, input.Type, have.Type, "the packet type")
-				assert.Equal(t, input.Namespace, have.Namespace, "the namespace:")
-				assert.Equal(t, input.AckID, have.AckID, "the ackID")
-				assert.IsType(t, input.Data, have.Data, "the data (type)")
+				assert.Equal(t, output.Type, have.Type, "the packet type")
+				assert.Equal(t, output.Namespace, have.Namespace, "the namespace:")
+				assert.Equal(t, output.AckID, have.AckID, "the ackID")
+				assert.IsType(t, output.Data, have.Data, "the data (type)")
 
 				switch _have := have.Data.(type) {
 				case *packetDataArray:
-					for i, wantx := range input.Data.(*packetDataArray).x {
+					for i, wantx := range output.Data.(*packetDataArray).x {
 						switch wx := wantx.(type) {
 						case io.Reader:
 							assert.Implements(t, (*io.Reader)(nil), _have.x[i])
@@ -88,10 +108,20 @@ func TestPacketV4(t *testing.T) {
 				}
 			}
 		},
-		"WriteTo": func(input PacketV4, output [][]byte, xErr error) testFn {
+		"WriteTo": func(testDataOpts ...testDataOptFunc) testFn { // func(input PacketV4, output [][]byte, xErr error) testFn {
 			return func(t *testing.T) {
 				for _, opt := range opts {
 					opt(t)
+				}
+
+				var d testData
+				for _, testDataOpt := range testDataOpts {
+					testDataOpt(&d)
+				}
+
+				input, output, xErr := d.rawPacketV4(), d.rawByteSlice, d.err
+				if d.altPacket != nil {
+					input = d.altPacketV4()
 				}
 
 				var have = new(bytes.Buffer)
@@ -114,53 +144,77 @@ func TestPacketV4(t *testing.T) {
 	}
 
 	spec := map[string]testParamsOutFn{
-		"CONNECT": func(*testing.T) (PacketV4, [][]byte, error) {
+		"CONNECT": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`0`)}
 			asPacket := *NewPacketV4().WithNamespace("/").(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"DISCONNECT": func(*testing.T) (PacketV4, [][]byte, error) {
+		"DISCONNECT": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`1/admin`)}
 			asPacket := *NewPacketV4().
 				WithType(DisconnectPacket.Byte()).
 				WithNamespace("/admin").(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"EVENT": func(*testing.T) (PacketV4, [][]byte, error) {
+		"EVENT": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`2["hello",1]`)}
 			asPacket := *NewPacketV4().
 				WithType(EventPacket.Byte()).
 				WithNamespace("/").
 				WithData([]interface{}{"hello", 1.0}).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"EVENT with AckID": func(*testing.T) (PacketV4, [][]byte, error) {
+		"EVENT with AckID": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`2/admin,456["project:delete",123]`)}
 			asPacket := *NewPacketV4().
 				WithType(EventPacket.Byte()).
 				WithNamespace("/admin").
 				WithData([]interface{}{"project:delete", 123.0}).
 				WithAckID(456).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"ACK": func(*testing.T) (PacketV4, [][]byte, error) {
+		"ACK": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`3/admin,456[]`)}
 			asPacket := *NewPacketV4().
 				WithType(AckPacket.Byte()).
 				WithNamespace("/admin").
 				WithData([]interface{}{}).
 				WithAckID(456).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"ERROR": func(*testing.T) (PacketV4, [][]byte, error) {
+		"ERROR": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`4/admin,"Not authorized"`)}
 			asPacket := *NewPacketV4().
 				WithType(ErrorPacket.Byte()).
 				WithNamespace("/admin").
 				WithData(&notAuthorized).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"BINARY EVENT": func(*testing.T) (PacketV4, [][]byte, error) {
+		"BINARY EVENT": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{
 				[]byte(`51-["hello",{"_placeholder":true,"num":0}]`),
 				{0x01, 0x02, 0x03},
@@ -169,9 +223,13 @@ func TestPacketV4(t *testing.T) {
 				WithType(BinaryEventPacket.Byte()).
 				WithNamespace("/").
 				WithData([]interface{}{"hello", bytes.NewReader([]byte{0x01, 0x02, 0x03})}).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"BINARY EVENT with AckID": func(*testing.T) (PacketV4, [][]byte, error) {
+		"BINARY EVENT with AckID": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{
 				[]byte(`51-/admin,456["hello",{"_placeholder":true,"num":0}]`),
 				{0x01, 0x02, 0x03},
@@ -181,9 +239,13 @@ func TestPacketV4(t *testing.T) {
 				WithNamespace("/admin").
 				WithData([]interface{}{"hello", bytes.NewReader([]byte{0x01, 0x02, 0x03})}).
 				WithAckID(456).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"BINARY ACK": func(*testing.T) (PacketV4, [][]byte, error) {
+		"BINARY ACK": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{
 				[]byte(`61-/admin,456[{"_placeholder":true,"num":0}]`),
 				{0x03, 0x02, 0x01},
@@ -193,23 +255,40 @@ func TestPacketV4(t *testing.T) {
 				WithNamespace("/admin").
 				WithData([]interface{}{bytes.NewReader([]byte{0x03, 0x02, 0x01})}).
 				WithAckID(456).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
 
 		// extra
-		"CONNECT /admin ns": func(*testing.T) (PacketV4, [][]byte, error) {
+		"CONNECT /admin ns": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`0/admin`)}
 			asPacket := *NewPacketV4().
 				WithNamespace("/admin").(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"CONNECT /admin ns and extra info": func(*testing.T) (PacketV4, [][]byte, error) {
+		"CONNECT /admin ns and extra info": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{[]byte(`0/admin?token=1234&uid=abcd`)}
 			asPacket := *NewPacketV4().
-				WithNamespace("/admin?token=1234&uid=abcd").(*PacketV4)
-			return asPacket, asBytes, nil
+				WithNamespace("/admin").(*PacketV4)
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) {
+					as2Packet := asPacket
+					as2Packet.WithNamespace("/admin?token=1234&uid=abcd")
+					d.altPacket = as2Packet
+				},
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
-		"BINARY ACK with /admin ns": func(*testing.T) (PacketV4, [][]byte, error) {
+		"BINARY ACK with /admin ns": func(*testing.T) []testDataOptFunc {
 			asBytes := [][]byte{
 				[]byte(`61-/admin,456{"stream":{"_placeholder":true,"num":0}}`),
 				{0x03, 0x02, 0x01},
@@ -219,13 +298,17 @@ func TestPacketV4(t *testing.T) {
 				WithNamespace("/admin").
 				WithData(map[string]interface{}{"stream": bytes.NewReader([]byte{0x03, 0x02, 0x01})}).
 				WithAckID(456).(*PacketV4)
-			return asPacket, asBytes, nil
+			return []testDataOptFunc{
+				func(d *testData) { d.rawPacket = asPacket },
+				func(d *testData) { d.rawByteSlice = asBytes },
+				func(d *testData) { d.err = nil },
+			}
 		},
 	}
 
 	for name, testParams := range spec {
 		for suffix, run := range runWithOptions {
-			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)))
+			t.Run(fmt.Sprintf("%s.%s", name, suffix), run(testParams(t)...))
 		}
 	}
 }

--- a/protocol/scratch.go
+++ b/protocol/scratch.go
@@ -291,6 +291,8 @@ func defaultMarshalBinaryData(num int, r io.Reader) ([]byte, error) {
 
 func withPacketData(v interface{}) packetData {
 	switch val := v.(type) {
+	case nil:
+		return nil
 	case string:
 		return &packetDataString{x: &val}
 	case *string:
@@ -304,7 +306,7 @@ func withPacketData(v interface{}) packetData {
 	case error:
 		return readWriteErr{val}
 	default:
-		return readWriteErr{ErrUnexpectedPacketType.F(val)}
+		return readWriteErr{ErrUnexpectedPacketType.F(val).KV("fn", "withPacketData")}
 	}
 }
 

--- a/server.v1.go
+++ b/server.v1.go
@@ -45,7 +45,7 @@ func NewServerV1(opts ...Option) *ServerV1 {
 
 	v1.eio = eio.NewServerV2(
 		eio.WithPath(*v1.path),
-		eio.WithInitialPackets(autoConnect(v1, siop.NewPacketV2)),
+		eio.WithInitialPackets(autoConnect(v1)),
 	).(eio.EIOServer)
 	v1.eio.With(opts...)
 
@@ -76,7 +76,6 @@ func (v1 *ServerV1) new(opts ...Option) Server {
 	v1.inSocketV1.binary = true   // for the v1 implementation this always is set to true
 	v1.inSocketV1.compress = true // for the v1 implementation this always is set to true
 
-	// v1.inSocketV1.tr = func() siot.Transporter { return v1.transport }
 	v1.inSocketV1.setTransporter(v1.transport)
 
 	return v1

--- a/server.v1_test.go
+++ b/server.v1_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -130,6 +131,10 @@ func PollingTestV1(opts []func(*testing.T), testDataOpts ...testDataOptFunc) fun
 				for i, want := range request {
 					x++
 					have := client[i].polling.grab()
+					if !reflect.DeepEqual(want, have) {
+						time.Sleep(100 * time.Millisecond) // retry one-time, because the polling could be a little off.
+						have = append(have, client[i].polling.grab()...)
+					}
 					assert.Equal(t, want, have, "[%s] idx: %d", reqType, i)
 				}
 				continue
@@ -235,9 +240,9 @@ func SendingToTheClientV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
-				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
-				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `42["hello","can you hear me?",1,2,"abc"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -269,9 +274,9 @@ func SendingToAllClientsExceptTheSenderV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["broadcast","Hello friends!"]`},
-				{`40`, `6`, `42["broadcast","Hello friends!"]`},
-				{`40`, `6`},
+				{`40`, `42["broadcast","Hello friends!"]`},
+				{`40`, `42["broadcast","Hello friends!"]`},
+				{`40`},
 			},
 		}
 		count = len(want["grab1"])
@@ -305,11 +310,11 @@ func SendingToAllClientsInGameRoomExceptSenderV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["nice game","let's play a game"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game"]`},
-				{`40`, `6`},
-				{`40`, `6`}, // sender...
+				{`40`, `42["nice game","let's play a game"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game"]`},
+				{`40`},
+				{`40`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -346,19 +351,19 @@ func SendingToAllClientsInGame1AndOrGame2RoomExceptSenderV1(*testing.T) []testDa
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`}, // sender...
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -398,11 +403,11 @@ func SendingToAllClientsInGameRoomIncludingSenderV1(*testing.T) []testDataOptFun
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
+				{`40`, `42["big-announcement","the game will start soon"]`},
+				{`40`},
+				{`40`, `42["big-announcement","the game will start soon"]`},
+				{`40`},
+				{`40`, `42["big-announcement","the game will start soon"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -446,11 +451,11 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV1(*testing.T) []te
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`}, // 42/myNamespace,["bigger-announcement","the tournament will start soon"]
+				{`40`, `40/myNamespace`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`}, // 42/myNamespace,["bigger-announcement","the tournament will start soon"]
 			},
 		}
 		count = len(want["send1"])
@@ -503,11 +508,11 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV1(*testing.T) [
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`40`, `6`, `42/myNamespace,["event","message"]`},
-				{`40`, `6`},
-				{`40`, `6`},
-				{`40`, `6`},
-				{`40`, `6`, `42/myNamespace,["event","message"]`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["event","message"]`},
+				{`40`},
+				{`40`, `40/myNamespace`},
+				{`40`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["event","message"]`},
 			},
 		}
 		count = len(want["send1"])
@@ -560,9 +565,9 @@ func SendingToIndividualSocketIDPrivateMessageV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["hey","I just met you #1"]`},
-				{`40`, `6`, `42["hey","I just met you #2"]`},
-				{`40`, `6`, `42["hey","I just met you #0"]`},
+				{`40`, `42["hey","I just met you #1"]`},
+				{`40`, `42["hey","I just met you #2"]`},
+				{`40`, `42["hey","I just met you #0"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -604,7 +609,7 @@ func SendingWithAcknowledgementV1(t *testing.T) []testDataOptFunc {
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
-			"grab1": {{`40`, `6`, `421["question","do you think so?"]`}},
+			"grab1": {{`40`, `421["question","do you think so?"]`}},
 			"send2": {{`431["answer",42]`}},
 		}
 		count = len(want["grab1"])
@@ -652,11 +657,11 @@ func SendingToAllConnectedClientsV1(*testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -699,11 +704,11 @@ func OnEventV1(t *testing.T) []testDataOptFunc {
 				{`41`}, nil, nil, nil, nil,
 			},
 			"grab2": {
-				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
+				{`40`, `42["say goodbye","disconnecting..."]`},
+				{`40`},
+				{`40`, `42["say goodbye","disconnecting..."]`},
+				{`40`},
+				{`40`, `42["say goodbye","disconnecting..."]`},
 			},
 		}
 		count = len(want["send1"])
@@ -759,7 +764,7 @@ func RejectTheClientV1(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"connect_query": {{`access=true`}, {`access=false`}},
-			"grab1":         {{`40`, `6`, `42["hello",1]`}, {`40`, `6`, `44{"message":"not authorized"}`}},
+			"grab1":         {{`40`, `42["hello",1]`}, {`40`, `44{"message":"not authorized"}`}},
 		}
 		count = len(want["connect_query"])
 		cnt   = int64(0)

--- a/server.v2.go
+++ b/server.v2.go
@@ -26,7 +26,7 @@ func NewServerV2(opts ...Option) *ServerV2 {
 	v1 := v2.prev
 	v1.eio = eio.NewServerV3(
 		eio.WithPath(*v1.path),
-		eio.WithInitialPackets(autoConnect(v1, siop.NewPacketV2)),
+		eio.WithInitialPackets(autoConnect(v1)),
 	).(eio.EIOServer) // v2 uses the default engineio protocol v3
 	v1.eio.With(opts...)
 

--- a/server.v2.runback.go
+++ b/server.v2.runback.go
@@ -18,6 +18,7 @@ func doConnectPacketV2(v2 *ServerV2) func(SocketID, siot.Socket, *Request) error
 		v2.setNsp(socket.Namespace)
 
 		if fn, ok := v2.onConnect[socket.Namespace]; ok {
+			tr.Send(socketID, nil, siop.WithType(byte(siop.ConnectPacket)), siop.WithNamespace(socket.Namespace))
 			return fn(&SocketV2{inSocketV2: v2.inSocketV2.clone(), req: req})
 		}
 		return ErrOnConnectSocket

--- a/server.v2_test.go
+++ b/server.v2_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -134,6 +135,10 @@ func PollingTestV2(opts []func(*testing.T), testDataOpts ...testDataOptFunc) tes
 				for i, want := range request {
 					x++
 					have := client[i].polling.grab()
+					if !reflect.DeepEqual(want, have) {
+						time.Sleep(100 * time.Millisecond)
+						have = append(have, client[i].polling.grab()...)
+					}
 					assert.Equal(t, want, have, "[%s] idx: %d", reqType, i)
 				}
 				continue
@@ -158,9 +163,9 @@ func SendingToTheClientV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
-				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
-				{`40`, `6`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `42["hello","can you hear me?",1,2,"abc"]`},
+				{`40`, `42["hello","can you hear me?",1,2,"abc"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -194,9 +199,9 @@ func SendingToAllClientsExceptTheSenderV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["broadcast","Hello friends!"]`},
-				{`40`, `6`, `42["broadcast","Hello friends!"]`},
-				{`40`, `6`},
+				{`40`, `42["broadcast","Hello friends!"]`},
+				{`40`, `42["broadcast","Hello friends!"]`},
+				{`40`},
 			},
 		}
 		count = len(want["grab1"])
@@ -232,11 +237,11 @@ func SendingToAllClientsInGameRoomExceptSenderV2(t *testing.T) []testDataOptFunc
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["nice game","let's play a game"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game"]`},
-				{`40`, `6`},
-				{`40`, `6`}, // sender...
+				{`40`, `42["nice game","let's play a game"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game"]`},
+				{`40`},
+				{`40`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -275,19 +280,19 @@ func SendingToAllClientsInGame1AndOrGame2RoomExceptSenderV2(t *testing.T) []test
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`, `42["nice game","let's play a game (too)"]`},
-				{`40`, `6`},
-				{`40`, `6`}, // sender...
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`, `42["nice game","let's play a game (too)"]`},
+				{`40`},
+				{`40`}, // sender...
 			},
 		}
 		count = len(want["grab1"])
@@ -329,11 +334,11 @@ func SendingToAllClientsInGameRoomIncludingSenderV2(t *testing.T) []testDataOptF
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["big-announcement","the game will start soon"]`},
+				{`40`, `42["big-announcement","the game will start soon"]`},
+				{`40`},
+				{`40`, `42["big-announcement","the game will start soon"]`},
+				{`40`},
+				{`40`, `42["big-announcement","the game will start soon"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -379,11 +384,11 @@ func SendingToAllClientsInNamespaceMyNamespaceIncludingSenderV2(t *testing.T) []
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
-				{`40`, `6`},
-				{`40`, `6`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
+				{`40`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["bigger-announcement","the tournament will start soon"]`},
 			},
 		}
 		count = len(want["send1"])
@@ -438,11 +443,11 @@ func SendingToASpecificRoomInNamespaceMyNamespaceIncludingSenderV2(t *testing.T)
 				{`40/myNamespace,`},
 			},
 			"grab1": {
-				{`40`, `6`, `42/myNamespace,["event","message"]`},
-				{`40`, `6`},
-				{`40`, `6`},
-				{`40`, `6`},
-				{`40`, `6`, `42/myNamespace,["event","message"]`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["event","message"]`},
+				{`40`},
+				{`40`, `40/myNamespace`},
+				{`40`},
+				{`40`, `40/myNamespace`, `42/myNamespace,["event","message"]`},
 			},
 		}
 		count = len(want["send1"])
@@ -497,9 +502,9 @@ func SendingToIndividualSocketIDPrivateMessageV2(t *testing.T) []testDataOptFunc
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["hey","I just met you #1"]`},
-				{`40`, `6`, `42["hey","I just met you #2"]`},
-				{`40`, `6`, `42["hey","I just met you #0"]`},
+				{`40`, `42["hey","I just met you #1"]`},
+				{`40`, `42["hey","I just met you #2"]`},
+				{`40`, `42["hey","I just met you #0"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -542,7 +547,7 @@ func SendingWithAcknowledgementV2(t *testing.T) []testDataOptFunc {
 		wait = new(sync.WaitGroup)
 
 		want = map[string][][]string{
-			"grab1": {{`40`, `6`, `421["question","do you think so?"]`}},
+			"grab1": {{`40`, `421["question","do you think so?"]`}},
 			"send2": {{`431["answer",42]`}},
 		}
 		count = len(want["grab1"])
@@ -592,11 +597,11 @@ func SendingToAllConnectedClientsV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"grab1": {
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
-				{`40`, `6`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
+				{`40`, `42["*","an event sent to all connected clients"]`},
 			},
 		}
 		count = len(want["grab1"])
@@ -642,11 +647,11 @@ func OnEventV2(t *testing.T) []testDataOptFunc {
 				{`41`}, nil, nil, nil, nil,
 			},
 			"grab2": {
-				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
-				{`40`, `6`},
-				{`40`, `6`, `42["say goodbye","disconnecting..."]`},
+				{`40`, `42["say goodbye","disconnecting..."]`},
+				{`40`},
+				{`40`, `42["say goodbye","disconnecting..."]`},
+				{`40`},
+				{`40`, `42["say goodbye","disconnecting..."]`},
 			},
 		}
 		count = len(want["send1"])
@@ -704,7 +709,7 @@ func RejectTheClientV2(t *testing.T) []testDataOptFunc {
 
 		want = map[string][][]string{
 			"connect_query": {{`access=true`}, {`access=false`}},
-			"grab1":         {{`40`, `6`, `42["hello",1]`}, {`40`, `6`, `44{"message":"not authorized"}`}},
+			"grab1":         {{`40`, `42["hello",1]`}, {`40`, `44{"message":"not authorized"}`}},
 		}
 		count = len(want["connect_query"])
 		cnt   = int64(0)

--- a/server_test.go
+++ b/server_test.go
@@ -379,6 +379,7 @@ func (c *v1PollingClient) grab() (rtn []string) {
 	for i := range have {
 		rtn = append(rtn, string(have[i]))
 	}
+
 	return rtn
 }
 func (c *v1PollingClient) get(URL string) [][]byte {


### PR DESCRIPTION
- Fix the SocketIO connect protocol 
- Update SocketIO server and packet tests

When SocketIO connects to a namespace the client expects a return connect call. That was only happening during auto-connect, and not during normal server connections. Now the code correctly returns a connection to the client for every successful server connection.

Updates the tests so they reflect the change in how namespaces are processed. The packet tests are more flexible (like the SocketIO server tests). Added an extra check around polling in the server tests, so they aren't flaky.

[fixes #61]