### PR TITLE
Update the callback.Wrap struct to work with maps

### DIFF
--- a/callback/callback.go
+++ b/callback/callback.go
@@ -1,6 +1,7 @@
 package callback
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -102,6 +103,13 @@ func (fn Wrap) Callback(data ...interface{}) (err error) {
 			in[i] = reflect.ValueOf(data[i].(error))
 		case io.Reader:
 			in[i] = reflect.ValueOf(data[i].(io.Reader))
+		case map[string]interface{}:
+			b, err := json.Marshal(data[i])
+			if err != nil {
+				return err
+			}
+			val.Unserialize(string(b))
+			in[i] = reflect.ValueOf(val.(inter).Interface())
 		default:
 			v = fmt.Sprintf("%v", data[i]) // this should work for scalar types
 			val.Unserialize(v)


### PR DESCRIPTION
The callback wrap method didn't understand the map type when doing reflection. This commit adds the map type and serializes to JSON so that the Unserialize() on the map object will work as expected.

NOTE: that custom Serialize() and Unserialize() objects can be always used instead of the generic callback.Wrap struct. Examples were added to the callback_test.go file.

[ fixes #66 ]