### PR TITLE
Add a socketio.WithPath to change the SIO path

### DIFF
--- a/engineio/option.go
+++ b/engineio/option.go
@@ -4,3 +4,14 @@ import with "github.com/njones/socketio/internal/option"
 
 type Option = with.Option
 type OptionWith = with.OptionWith
+
+// withPath stores all of the external options for WithPath
+var withPath = make(with.OptionRegistry)
+
+// WithPath could be accessed from SocketIO engine,
+func WithPath(path string) Option {
+	if opt, ok := withPath.Latest().(func(string) Option); ok {
+		return opt(path)
+	}
+	return func(OptionWith) {}
+}

--- a/engineio/option.v2.go
+++ b/engineio/option.v2.go
@@ -8,18 +8,20 @@ import (
 	eiot "github.com/njones/socketio/engineio/transport"
 )
 
-func WithCodec(codec eiot.Codec) Option {
-	return func(o OptionWith) {
-		if v, ok := o.(*serverV2); ok {
-			v.codec = codec
+func init() {
+	withPath[1] = func(path string) Option {
+		return func(o OptionWith) {
+			if v, ok := o.(*serverV2); ok {
+				v.path = &path
+			}
 		}
 	}
 }
 
-func WithPath(path string) Option {
+func WithCodec(codec eiot.Codec) Option {
 	return func(o OptionWith) {
 		if v, ok := o.(*serverV2); ok {
-			v.path = &path
+			v.codec = codec
 		}
 	}
 }

--- a/internal/option/option.go
+++ b/internal/option/option.go
@@ -2,3 +2,17 @@ package option
 
 type Option func(OptionWith)
 type OptionWith interface{ With(...Option) }
+type OptionRegistry map[int]interface{}
+
+func (r OptionRegistry) Latest() interface{} {
+	if len(r) == 0 {
+		return func(OptionWith) {}
+	}
+	var k, max int
+	for k = range r {
+		if k > max {
+			max = k
+		}
+	}
+	return r[k]
+}

--- a/option.v1.go
+++ b/option.v1.go
@@ -1,0 +1,23 @@
+package socketio
+
+import (
+	"strings"
+
+	eio "github.com/njones/socketio/engineio"
+)
+
+// WithPath changes the path when using the SocketIO engine in
+// conjunction with EngineIO. Use the engineio.WithPath to change
+// the path when only using EngineIO.
+func WithPath(path string) Option {
+	return func(o OptionWith) {
+		if v, ok := o.(*ServerV1); ok {
+			if path == "" {
+				return
+			}
+			path = "/" + strings.Trim(path, "/") + "/"
+			v.path = &path
+			v.eio.With(eio.WithPath(path))
+		}
+	}
+}

--- a/server.v3_test.go
+++ b/server.v3_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -23,6 +24,58 @@ var testingOptionsV3 = []socketio.Option{
 	engineio.WithSessionShave(1 * time.Millisecond),
 	engineio.WithPingTimeout(1 * time.Second),
 	engineio.WithPingInterval(500 * time.Millisecond),
+}
+
+func TestSocketIOPathV3(t *testing.T) {
+
+	tests := map[string]struct {
+		withPath string
+		reqPath  string
+		expect   string
+	}{
+		"no path": {
+			withPath: "",
+			reqPath:  "socket.io",
+			expect:   `^(\d+\{.[^\}]*\})+$`,
+		},
+		"socket.io": {
+			withPath: "socket.io",
+			reqPath:  "socket.io",
+			expect:   `^(\d+\{.[^\}]*\})+$`,
+		},
+		"socket.io with left slash": {
+			withPath: "/socket.io",
+			reqPath:  "socket.io",
+			expect:   `^(\d+\{.[^\}]*\})+$`,
+		},
+		"socket.io with right slash": {
+			withPath: "socket.io/",
+			reqPath:  "socket.io",
+			expect:   `^(\d+\{.[^\}]*\})+$`,
+		},
+		"socket.io with both slash": {
+			withPath: "/socket.io/",
+			reqPath:  "socket.io",
+			expect:   `^(\d+\{.[^\}]*\})+$`,
+		},
+		"testing": {
+			withPath: "testing",
+			reqPath:  "testing",
+			expect:   `^(\d+\{.[^\}]*\})+$`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/%s/?EIO=4&transport=polling", test.reqPath), nil)
+			rsp := httptest.NewRecorder()
+
+			svr := socketio.NewServerV3(socketio.WithPath(test.withPath))
+			svr.ServeHTTP(rsp, req)
+
+			assert.Regexp(t, test.expect, rsp.Body.String())
+		})
+	}
 }
 
 func TestServerV3(t *testing.T) {


### PR DESCRIPTION
The engineio.WithPath option would change the internal EngineIO path, but left the internal SocketIO path untouched which caused issues with the service because the SocketIO and EngineIO internal paths didn't match.

This commit adds a socketio.WithPath option to change SocketIO paths (and the underlining EngineIO path).

This commit also abstracts the EngineIO WithPath option to guarantee that the code will compile even if the option is removed when building a specific version of the library. In this case it's not really important, but this is to showcase how it will work for new and refactored options.

Tests around adding the socketio.WithPath have been added separately outside of the integration tests, because they are testing a specific server configuration rather than a SocketIO implementation.

[fixes #70]