### PR TITLE
Encode the SIO socketID generated prefix

### DIFF
--- a/server_benchmark_test.go
+++ b/server_benchmark_test.go
@@ -1,0 +1,168 @@
+package socketio
+
+import (
+	"crypto/md5"
+	"encoding/base32"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"hash/crc32"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	sios "github.com/njones/socketio/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSocketIDQuickPrefix(t *testing.T) {
+	now := time.Date(1946, time.February, 14, 10, 00, 00, 00, time.UTC) // February 14, 1946 - The date ENIAC was demonstrated to the world
+	socketID := sios.ID(_socketIDQuickPrefix(now)() + "ABC123def456")
+
+	assert.Equal(t, sios.ID("f09f838af09f8384f09f839bf09f8387f09f8396::ABC123def456"), socketID)
+	assert.Equal(t, "f09f838af09f8384f09f839bf09f8387f09f8396::ABC123def456", socketID.String())
+	assert.Equal(t, "f09f838af09f8384f09f839bf09f8387f09f8396::ABC123def456", fmt.Sprintf("%s", socketID))
+	assert.Equal(t, "🃊🃄🃛🃇🃖::ABC123def456", socketID.GoString())
+	assert.Equal(t, "🃊🃄🃛🃇🃖::ABC123def456", fmt.Sprintf("%#v", socketID))
+}
+
+func socketIDQuickPrefix32() string {
+	src := rand.NewSource(time.Now().UnixNano())
+	rnd := rand.New(src)
+
+	cards := [][]rune{
+		{127137, 127150}, // spades
+		{127153, 127166}, // hearts
+		{127169, 127182}, // diamonds
+		{127185, 127198}, // clubs
+	}
+
+	prefix := make([]rune, 5)
+	for i := range prefix {
+		suit := rnd.Intn(4)
+		card := int32(rnd.Intn(int(cards[suit][1]-cards[suit][0]-1))) + cards[suit][0]
+		prefix[i] = card
+	}
+
+	enc := base32.HexEncoding.EncodeToString([]byte(string(prefix)))
+	return enc + "::"
+}
+
+func socketIDQuickPrefix64() string {
+	src := rand.NewSource(time.Now().UnixNano())
+	rnd := rand.New(src)
+
+	cards := [][]rune{
+		{127137, 127150}, // spades
+		{127153, 127166}, // hearts
+		{127169, 127182}, // diamonds
+		{127185, 127198}, // clubs
+	}
+
+	prefix := make([]rune, 5)
+	for i := range prefix {
+		suit := rnd.Intn(4)
+		card := int32(rnd.Intn(int(cards[suit][1]-cards[suit][0]-1))) + cards[suit][0]
+		prefix[i] = card
+	}
+
+	enc := base64.StdEncoding.EncodeToString([]byte(string(prefix)))
+	return enc + "::"
+}
+
+func socketIDQuickPrefixHex() string {
+	src := rand.NewSource(time.Now().UnixNano())
+	rnd := rand.New(src)
+
+	cards := [][]rune{
+		{127137, 127150}, // spades
+		{127153, 127166}, // hearts
+		{127169, 127182}, // diamonds
+		{127185, 127198}, // clubs
+	}
+
+	prefix := make([]rune, 5)
+	for i := range prefix {
+		suit := rnd.Intn(4)
+		card := int32(rnd.Intn(int(cards[suit][1]-cards[suit][0]-1))) + cards[suit][0]
+		prefix[i] = card
+	}
+
+	enc := hex.EncodeToString([]byte(string(prefix)))
+	return enc + "::"
+}
+
+func socketIDQuickPrefixMD5() string {
+	src := rand.NewSource(time.Now().UnixNano())
+	rnd := rand.New(src)
+
+	cards := [][]rune{
+		{127137, 127150}, // spades
+		{127153, 127166}, // hearts
+		{127169, 127182}, // diamonds
+		{127185, 127198}, // clubs
+	}
+
+	prefix := make([]rune, 5)
+	for i := range prefix {
+		suit := rnd.Intn(4)
+		card := int32(rnd.Intn(int(cards[suit][1]-cards[suit][0]-1))) + cards[suit][0]
+		prefix[i] = card
+	}
+
+	hsh := md5.Sum([]byte(string(prefix)))
+	return string(hsh[:]) + "::"
+}
+
+func socketIDQuickPrefixCRC32() string {
+	src := rand.NewSource(time.Now().UnixNano())
+	rnd := rand.New(src)
+
+	cards := [][]rune{
+		{127137, 127150}, // spades
+		{127153, 127166}, // hearts
+		{127169, 127182}, // diamonds
+		{127185, 127198}, // clubs
+	}
+
+	prefix := make([]rune, 5)
+	for i := range prefix {
+		suit := rnd.Intn(4)
+		card := int32(rnd.Intn(int(cards[suit][1]-cards[suit][0]-1))) + cards[suit][0]
+		prefix[i] = card
+	}
+
+	i := crc32.ChecksumIEEE([]byte(string(prefix)))
+	return strconv.FormatUint(uint64(i), 10) + "::"
+}
+
+func BenchmarkSocketIDPrefixEncoding32(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		socketIDQuickPrefix32()
+	}
+}
+
+func BenchmarkSocketIDPrefixEncoding64(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		socketIDQuickPrefix64()
+	}
+}
+
+func BenchmarkSocketIDPrefixEncodingHex(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		socketIDQuickPrefixHex()
+	}
+}
+
+func BenchmarkSocketIDPrefixEncodingMD5(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		socketIDQuickPrefixMD5()
+	}
+}
+
+func BenchmarkSocketIDPrefixEncodingCRC32(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		socketIDQuickPrefixMD5()
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -3,11 +3,21 @@ package session
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
+	"strings"
 )
 
 type ID string
 
-func (id ID) String() string            { return string(id) }
+func (id ID) String() string { return string(id) }
+func (id ID) GoString() string {
+	if b, a, found := strings.Cut(string(id), "::"); found {
+		if str, err := hex.DecodeString(b); err == nil {
+			return string(str) + "::" + a
+		}
+	}
+	return string(id)
+}
 func (id ID) Room(prefix string) string { return prefix + string(id) }
 
 var GenerateID = func(string) ID {


### PR DESCRIPTION
The prefix is encoded to present ASCII characters during logging. The unicode characters can still be seen, by using GoString() or the "%#v" formatting function for the `log` and `fmt` Printf() function.

The prefix generator function was refactored to accept an injected date, for testing purposes.

Updating the prefix via a user function has not been implemented, as the ID type needs to change to accommodate this request. Providing a user function will be in a future commit.

[fixes #69]